### PR TITLE
Enables trivial orchestrators

### DIFF
--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -45,9 +45,23 @@ class Orchestrator:
         the durable extension.
         """
         self.durable_context = context
-
-        self.generator = self.fn(self.durable_context)
+        self.generator = None
         suspended = False
+
+        fn_output = self.fn(self.durable_context)
+        # If `fn_output` is not an Iterator, then the orchestrator
+        # function does not make use of its context parameter. If so,
+        # `fn_output` is the return value instead of a generator
+        if isinstance(fn_output, Iterator):
+            self.generator = fn_output
+
+        else:
+            orchestration_state = OrchestratorState(
+                is_done=True,
+                output=fn_output,
+                actions=self.durable_context.actions,
+                custom_status=self.durable_context.custom_status)
+            return orchestration_state.to_json_string()
         try:
             generation_state = self._generate_next(None)
 


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/112
Previously, orchestrations that did not make use of its `context` parameter would error out. In practical terms, this meant that orchestrations that did not schedule any work would fail.

This change enables orchestrations to execute successfully without needing to schedule any work. The solution works by checking if the return value of `self.fn(self.durable_context` is an iterator ( a superclass of generators) or if it is already a value. In the former case, we proceed as normal and schedule work. In the latter, the orchestrator does not schedule any work and we return immediately.