### PR TITLE
Enabled nox to recognize docstring formatting errors

### DIFF
--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -45,9 +45,23 @@ class Orchestrator:
         the durable extension.
         """
         self.durable_context = context
-
-        self.generator = self.fn(self.durable_context)
+        self.generator = None
         suspended = False
+
+        fn_output = self.fn(self.durable_context)
+        # If `fn_output` is not an Iterator, then the orchestrator
+        # function does not make use of its context parameter. If so,
+        # `fn_output` is the return value instead of a generator
+        if isinstance(fn_output, Iterator):
+            self.generator = fn_output
+
+        else:
+            orchestration_state = OrchestratorState(
+                is_done=True,
+                output=fn_output,
+                actions=self.durable_context.actions,
+                custom_status=self.durable_context.custom_status)
+            return orchestration_state.to_json_string()
         try:
             generation_state = self._generate_next(None)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,10 +5,11 @@ def tests(session):
     # same as pip install -r -requirements.txt
     session.install("-r", "requirements.txt")
     session.install("pytest")
-    session.run("pytest","-v","tests")
+    session.run("pytest", "-v", "tests")
+
 
 @nox.session(python="3.7")
 def lint(session):
     session.install("flake8")
-    session.run("flake8","./azure/**py")
-
+    session.install("flake8-docstrings")
+    session.run("flake8", "./azure/")


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/111
This PR enables nox to recognize and report docstring formatting errors. We needed to add an extra linting dependency for this, and also fix the argument to `flake8` in the noxfile.