### PR TITLE
Reporting non-existent orchestrations in `start_new`

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -74,16 +74,15 @@ class DurableOrchestrationClient:
         if response[0] <= 202 and response[1]:
             return response[1]["id"]
         elif response[0] == 400:
-            # Orchestrator not found
+            # Orchestrator not found, report clean exception
             exception_data = response[1]
             exception_message = exception_data["ExceptionMessage"]
-            stack_trace = exception_data["StackTrace"]
-            exception_message += '\n' + stack_trace
             raise Exception(exception_message)
         else:
             # Catch all: simply surfacing the durable-extension exception
+            # we surface the stack trace too, since this may be a more involed exception
             exception_message = response[1]
-            raise Exception(exception_message))
+            raise Exception(exception_message)
 
     def create_check_status_response(self, request, instance_id):
         """Create a HttpResponse that contains useful information for \

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -73,10 +73,17 @@ class DurableOrchestrationClient:
 
         if response[0] <= 202 and response[1]:
             return response[1]["id"]
-        else:
-            # Surfacing the durable-extension exception
-            exception_message = response[1]
+        elif response[0] == 400:
+            # Orchestrator not found
+            exception_data = response[1]
+            exception_message = exception_data["ExceptionMessage"]
+            stack_trace = exception_data["StackTrace"]
+            exception_message += '\n' + stack_trace
             raise Exception(exception_message)
+        else:
+            # Catch all: simply surfacing the durable-extension exception
+            exception_message = response[1]
+            raise Exception(exception_message))
 
     def create_check_status_response(self, request, instance_id):
         """Create a HttpResponse that contains useful information for \

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -74,7 +74,7 @@ class DurableOrchestrationClient:
         if response[0] <= 202 and response[1]:
             return response[1]["id"]
         else:
-            return None
+            raise Exception(f"Failed to start orchestration named \"{orchestration_function_name}\". Did you make a typo?")
 
     def create_check_status_response(self, request, instance_id):
         """Create a HttpResponse that contains useful information for \

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -74,7 +74,9 @@ class DurableOrchestrationClient:
         if response[0] <= 202 and response[1]:
             return response[1]["id"]
         else:
-            raise Exception(f"Failed to start orchestration named \"{orchestration_function_name}\". Did you make a typo?")
+            err_message = f"Failed to start orchestration: {orchestration_function_name}."\
+                "Did you make a typo?"
+            raise Exception(err_message)
 
     def create_check_status_response(self, request, instance_id):
         """Create a HttpResponse that contains useful information for \

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -74,9 +74,9 @@ class DurableOrchestrationClient:
         if response[0] <= 202 and response[1]:
             return response[1]["id"]
         else:
-            err_message = f"Failed to start orchestration: {orchestration_function_name}."\
-                "Did you make a typo?"
-            raise Exception(err_message)
+            # Surfacing the durable-extension exception
+            exception_message = response[1]
+            raise Exception(exception_message)
 
     def create_check_status_response(self, request, instance_id):
         """Create a HttpResponse that contains useful information for \


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/141

We now throw an exception when start_new fails, whereas before we simply returned `None`. In doing so, we avoid throwing an internal exception (server response 500) when calling `client.create_check_status_response`.

In practice, this meant that, before, users hitting an `HTTPTrigger` with a typo on the orchestration name would see an internal exception with little debug information. Now, we report the real cause of the error and suggest a fix: looking for typos.

I would also love it if we could display this error, and others, as part of an HTTP response. Reading it on the terminal, while common practice, is not as nice, in my opinion.

Finally, this is also an error in Durable-JS. 