### PR TITLE
ContinueAsNew works, needed to mark the orchestrator as completed

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -1,6 +1,6 @@
 import json
 import datetime
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Optional
 
 from . import (RetryOptions, TaskSet)
 from .FunctionContext import FunctionContext
@@ -32,6 +32,7 @@ class DurableOrchestrationContext:
         self._custom_status: Any = None
         self._new_uuid_counter: int = 0
         self._sub_orchestrator_counter: int = 0
+        self._continue_as_new_task: Optional[Task] = None
         self.call_activity = lambda n, i=None: call_activity_task(
             state=self.histories,
             name=n,
@@ -65,7 +66,7 @@ class DurableOrchestrationContext:
             state=self.histories,
             name=n)
         self.new_uuid = lambda: new_uuid(context=self)
-        self.continue_as_new = lambda i: continue_as_new(input_=i)
+        self.continue_as_new = lambda i: continue_as_new(context=self, input_=i)
         self.task_any = lambda t: task_any(tasks=t)
         self.task_all = lambda t: task_all(tasks=t)
         self.create_timer = lambda d: create_timer_task(state=self.histories, fire_at=d)
@@ -344,3 +345,14 @@ class DurableOrchestrationContext:
             Object containing function level attributes not used by durable orchestrator.
         """
         return self._function_context
+
+    @property
+    def continue_as_new_task(self) -> Task:
+        """Get the continue_as_new task, if it has produced.
+
+        Returns
+        -------
+        Task:
+            The continue as new task
+        """
+        return self._continue_as_new_task

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -1,6 +1,6 @@
 import json
 import datetime
-from typing import List, Any, Dict, Optional
+from typing import List, Any, Dict
 
 from . import (RetryOptions, TaskSet)
 from .FunctionContext import FunctionContext
@@ -32,7 +32,7 @@ class DurableOrchestrationContext:
         self._custom_status: Any = None
         self._new_uuid_counter: int = 0
         self._sub_orchestrator_counter: int = 0
-        self._continue_as_new_task: Optional[Task] = None
+        self._continue_as_new_flag: bool = False
         self.call_activity = lambda n, i=None: call_activity_task(
             state=self.histories,
             name=n,
@@ -347,12 +347,6 @@ class DurableOrchestrationContext:
         return self._function_context
 
     @property
-    def continue_as_new_task(self) -> Optional[Task]:
-        """Get the continue_as_new task, if it was produced.
-
-        Returns
-        -------
-        Task:
-            The continue as new task
-        """
-        return self._continue_as_new_task
+    def will_continue_as_new(self) -> bool:
+        """Return true if continue_as_new was called."""
+        return self._continue_as_new_flag

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -347,8 +347,8 @@ class DurableOrchestrationContext:
         return self._function_context
 
     @property
-    def continue_as_new_task(self) -> Task:
-        """Get the continue_as_new task, if it has produced.
+    def continue_as_new_task(self) -> Optional[Task]:
+        """Get the continue_as_new task, if it was produced.
 
         Returns
         -------

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -119,10 +119,10 @@ class Orchestrator:
     def _handle_continue_as_new(self, task: Any, add_to_actions=False) -> Task:
         """Handle the continue_as_new special case.
 
-        A continue_as_new_task may not be yielded. In this case,
+        A continue_as_new_task might not be yielded. In this case,
         we only return to `handle` at the next yield (bad usage),
-        or when the function returns. If the function yielded after
-        whe `continue_as_new`, we ignore the task generated there
+        or when the function returns. If the function yielded a task after
+        the `continue_as_new`, we ignore the task generated there
         because `continue_as_new` should technically restart
         the orchestrator immediately.
 

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -119,7 +119,7 @@ class Orchestrator:
     def _handle_continue_as_new(self, task: Any, add_to_actions=False) -> Task:
         """Handle the continue_as_new special case.
 
-        A continue_as_new_task might not be yielded. In this case,
+        A continue_as_new task might not be yielded. In this case,
         we only return to `handle` at the next yield (bad usage),
         or when the function returns. If the function yielded a task after
         the `continue_as_new`, we ignore the task generated there

--- a/azure/durable_functions/tasks/continue_as_new.py
+++ b/azure/durable_functions/tasks/continue_as_new.py
@@ -6,6 +6,7 @@ from ..models.actions.ContinueAsNewAction import ContinueAsNewAction
 
 
 def continue_as_new(
+        context,
         input_: Any = None) -> Task:
     """Create a new continue as new action.
 
@@ -20,5 +21,7 @@ def continue_as_new(
         A Durable Task that causes the orchestrator reset and start as a new orchestration.
     """
     new_action = ContinueAsNewAction(input_)
+    task = Task(is_completed=True, is_faulted=False, action=new_action)
 
-    return Task(is_completed=True, is_faulted=False, action=new_action)
+    context._continue_as_new_task = task
+    return task

--- a/azure/durable_functions/tasks/continue_as_new.py
+++ b/azure/durable_functions/tasks/continue_as_new.py
@@ -21,4 +21,4 @@ def continue_as_new(
     """
     new_action = ContinueAsNewAction(input_)
 
-    return Task(is_completed=False, is_faulted=False, action=new_action)
+    return Task(is_completed=True, is_faulted=False, action=new_action)

--- a/azure/durable_functions/tasks/continue_as_new.py
+++ b/azure/durable_functions/tasks/continue_as_new.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from ..models.Task import (
-    Task)
 from ..models.actions.ContinueAsNewAction import ContinueAsNewAction
 
 
@@ -16,6 +14,6 @@ def continue_as_new(
         The JSON-serializable input to pass to the activity function.
     """
     new_action = ContinueAsNewAction(input_)
-    task = Task(is_completed=True, is_faulted=False, action=new_action)
 
-    context._continue_as_new_task = task
+    context.actions.append([new_action])
+    context._continue_as_new_flag = True

--- a/azure/durable_functions/tasks/continue_as_new.py
+++ b/azure/durable_functions/tasks/continue_as_new.py
@@ -7,21 +7,15 @@ from ..models.actions.ContinueAsNewAction import ContinueAsNewAction
 
 def continue_as_new(
         context,
-        input_: Any = None) -> Task:
+        input_: Any = None):
     """Create a new continue as new action.
 
     Parameters
     ----------
     input_: Any
         The JSON-serializable input to pass to the activity function.
-
-    Returns
-    -------
-    Task
-        A Durable Task that causes the orchestrator reset and start as a new orchestration.
     """
     new_action = ContinueAsNewAction(input_)
     task = Task(is_completed=True, is_faulted=False, action=new_action)
 
     context._continue_as_new_task = task
-    return task

--- a/tests/orchestrator/test_continue_as_new.py
+++ b/tests/orchestrator/test_continue_as_new.py
@@ -25,6 +25,7 @@ def add_hello_action(state: OrchestratorState, input_: str):
 def add_continue_as_new_action(state: OrchestratorState, input_: str):
     action = ContinueAsNewAction(input_=input_)
     state.actions.append([action])
+    state._is_done = True
 
 
 def add_hello_completed_events(

--- a/tests/orchestrator/test_continue_as_new.py
+++ b/tests/orchestrator/test_continue_as_new.py
@@ -10,7 +10,7 @@ from azure.durable_functions.models.actions.ContinueAsNewAction \
 
 def generator_function(context):
     yield context.call_activity("Hello", "Tokyo")
-    yield context.continue_as_new("Cause I can")
+    context.continue_as_new("Cause I can")
 
 
 def base_expected_state(output=None) -> OrchestratorState:


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/148

This PR fixes `continue_as_new`, a feature that was failing silently before. Judging from the JS code, it appears that `continue_as_new` actions should mark the orchestrator as "completed", and fixing this marker made `continue_as_new` work as expected.

Before merging, I could love some clarification on why this fix worked, which I believe must have to do with the expectations of `durable-extention`. I still do not understand why this failed silently, as I was expecting, at least, some kind of "non-determinism" exception.