### PR TITLE
Serialize False as a return value for orchestrators

### DIFF
--- a/azure/durable_functions/models/OrchestratorState.py
+++ b/azure/durable_functions/models/OrchestratorState.py
@@ -77,7 +77,7 @@ class OrchestratorState:
         json_dict = {}
         add_attrib(json_dict, self, '_is_done', 'isDone')
         self._add_actions(json_dict)
-        if self._output:
+        if not (self._output is None):
             json_dict['output'] = self._output
         if self._error:
             json_dict['error'] = self._error

--- a/tests/orchestrator/test_serialization.py
+++ b/tests/orchestrator/test_serialization.py
@@ -1,0 +1,30 @@
+from tests.test_utils.ContextBuilder import ContextBuilder
+from .orchestrator_test_utils \
+    import get_orchestration_state_result, assert_orchestration_state_equals, assert_valid_schema
+from azure.durable_functions.models.OrchestratorState import OrchestratorState
+
+def base_expected_state(output=None) -> OrchestratorState:
+    return OrchestratorState(is_done=False, actions=[], output=output)
+
+def generator_function(context):
+    return False
+
+def test_serialization_of_False():
+    """Test that an orchestrator can return False."""
+
+    context_builder = ContextBuilder("serialize False")
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function)
+
+    expected_state = base_expected_state(output=False)
+
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    # Since we're essentially testing the `to_json` functionality,
+    # we explicitely ensure that the output is set
+    expected["output"] = False
+
+    assert_valid_schema(result)
+    assert_orchestration_state_equals(expected, result)


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/155

This PR represented a simple change with important consequences, and some implications about coding style. Before, orchestrators failed to serialize their return value when it's value was `False`. The reason why is that we performed a faulty check in our serialization logic. The check was to avoid serializing a `None` value, but it was written as:

```python
if self._output:
    # serialize
```

In most cases, this is fine, because `None` values resolve to `False`. However, this broke when `self._output` was literally `False`. A safer check is `if self._output is not None`. We should consider a refactor where we rewrite all these "dangerous" checks into their safer alternative.

I'm tracking that task here: https://github.com/Azure/azure-functions-durable-python/issues/166
