### PR TITLE
CreateHttpManagementPayload

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -142,7 +142,7 @@ class DurableOrchestrationClient:
 
         Returns
         -------
-        dict
+        Dict[str, str]
             a dictionary object of orchestrator instance management urls
         """
         payload = self._orchestration_bindings.management_urls.copy()

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -130,7 +130,7 @@ class DurableOrchestrationClient:
 
     def get_client_response_links(
             self,
-            request: Optional[Any], instance_id: str) -> Dict[str, str]:
+            request: Optional[func.HttpRequest], instance_id: str) -> Dict[str, str]:
         """Create a dictionary of orchestrator management urls.
 
         Parameters

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -123,7 +123,7 @@ class DurableOrchestrationClient:
 
         Returns
         -------
-        dict
+        Dict[str, str]
             a dictionary object of orchestrator instance management urls
         """
         return self.get_client_response_links(None, instance_id)

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -112,7 +112,7 @@ class DurableOrchestrationClient:
             },
         }
         return func.HttpResponse(**response_args)
-    
+
     def create_http_management_payload(self, instance_id: str) -> Dict[str, str]:
         """Create a dictionary of orchestrator management urls.
 
@@ -128,7 +128,8 @@ class DurableOrchestrationClient:
         """
         return self.get_client_response_links(None, instance_id)
 
-    def get_client_response_links(self, 
+    def get_client_response_links(
+            self,
             request: Optional[Any], instance_id: str) -> Dict[str, str]:
         """Create a dictionary of orchestrator management urls.
 

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List, Any, Awaitable
+from typing import List, Any, Awaitable, Optional, Dict
 from time import time
 from asyncio import sleep
 from urllib.parse import urlparse, quote
@@ -112,13 +112,29 @@ class DurableOrchestrationClient:
             },
         }
         return func.HttpResponse(**response_args)
-
-    def get_client_response_links(self, request, instance_id):
+    
+    def create_http_management_payload(self, instance_id: str) -> Dict[str, str]:
         """Create a dictionary of orchestrator management urls.
 
         Parameters
         ----------
-        request : HttpRequest
+        instance_id : str
+            The ID of the orchestration instance to check.
+
+        Returns
+        -------
+        dict
+            a dictionary object of orchestrator instance management urls
+        """
+        return self.get_client_response_links(None, instance_id)
+
+    def get_client_response_links(self, 
+            request: Optional[Any], instance_id: str) -> Dict[str, str]:
+        """Create a dictionary of orchestrator management urls.
+
+        Parameters
+        ----------
+        request : Optional[HttpRequest]
             The HTTP request that triggered the current orchestration instance.
         instance_id : str
             The ID of the orchestration instance to check.
@@ -131,7 +147,8 @@ class DurableOrchestrationClient:
         payload = self._orchestration_bindings.management_urls.copy()
 
         for key, _ in payload.items():
-            if request.url:
+            request_is_not_none = not (request is None)
+            if request_is_not_none and request.url:
                 payload[key] = self._replace_url_origin(request.url, payload[key])
             payload[key] = payload[key].replace(
                 self._orchestration_bindings.management_urls["id"], instance_id)


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/161

This PR implements the `create_http_management_payload` functionality. All the pieces were already implemented as they were necessarily for `create_check_status_response`. This simply re-arranges them in the way required to create the HttpManagementPayload object.