### PR TITLE
The project now typechecks, improved IntelliSense

### DIFF
--- a/azure/durable_functions/models/DurableHttpRequest.py
+++ b/azure/durable_functions/models/DurableHttpRequest.py
@@ -1,19 +1,20 @@
-from typing import Dict, Any
+from typing import Dict, Union, Optional
 
-from azure.durable_functions.models import TokenSource
+from azure.durable_functions.models.TokenSource import TokenSource
 from azure.durable_functions.models.utils.json_utils import add_attrib, add_json_attrib
 
 
 class DurableHttpRequest:
     """Data structure representing a durable HTTP request."""
 
-    def __init__(self, method: str, uri: str, content: str = None, headers: Dict[str, str] = None,
-                 token_source: TokenSource = None):
+    def __init__(self, method: str, uri: str, content: Optional[str] = None,
+                 headers: Optional[Dict[str, str]] = None,
+                 token_source: Optional[TokenSource] = None):
         self._method: str = method
         self._uri: str = uri
-        self._content: str = content
-        self._headers: Dict[str, str] = headers
-        self._token_source: TokenSource = token_source
+        self._content: Optional[str] = content
+        self._headers: Optional[Dict[str, str]] = headers
+        self._token_source: Optional[TokenSource] = token_source
 
     @property
     def method(self) -> str:
@@ -26,29 +27,29 @@ class DurableHttpRequest:
         return self._uri
 
     @property
-    def content(self) -> str:
+    def content(self) -> Optional[str]:
         """Get the HTTP request content."""
         return self._content
 
     @property
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> Optional[Dict[str, str]]:
         """Get the HTTP request headers."""
         return self._headers
 
     @property
-    def token_source(self) -> TokenSource:
+    def token_source(self) -> Optional[TokenSource]:
         """Get the source of OAuth token to add to the request."""
         return self._token_source
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
         -------
-        Dict[str, Any]
+        Dict[str, Union[str, int]]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'method')
         add_attrib(json_dict, self, 'uri')
         add_attrib(json_dict, self, 'content')

--- a/azure/durable_functions/models/DurableOrchestrationBindings.py
+++ b/azure/durable_functions/models/DurableOrchestrationBindings.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict
+from typing import Dict, Optional
 
 from azure.durable_functions.models.FunctionContext import FunctionContext
 
@@ -13,11 +13,12 @@ class DurableOrchestrationBindings:
 
     # parameter names are as defined by JSON schema and do not conform to PEP8 naming conventions
     def __init__(self, taskHubName: str, creationUrls: Dict[str, str],
-                 managementUrls: Dict[str, str], rpcBaseUrl: str = None, **kwargs):
+                 managementUrls: Dict[str, str], rpcBaseUrl: Optional[str] = None, **kwargs):
         self._task_hub_name: str = taskHubName
         self._creation_urls: Dict[str, str] = creationUrls
         self._management_urls: Dict[str, str] = managementUrls
-        self._rpc_base_url: str = rpcBaseUrl
+        # TODO: we can remove the Optional once we drop support for 1.x, this is always provided in 2.x
+        self._rpc_base_url: Optional[str] = rpcBaseUrl
         self._client_data = FunctionContext(**kwargs)
 
     @property
@@ -36,7 +37,7 @@ class DurableOrchestrationBindings:
         return self._management_urls
 
     @property
-    def rpc_base_url(self) -> str:
+    def rpc_base_url(self) -> Optional[str]:
         """Get the base url communication between out of proc workers and the function host."""
         return self._rpc_base_url
 

--- a/azure/durable_functions/models/DurableOrchestrationBindings.py
+++ b/azure/durable_functions/models/DurableOrchestrationBindings.py
@@ -17,7 +17,8 @@ class DurableOrchestrationBindings:
         self._task_hub_name: str = taskHubName
         self._creation_urls: Dict[str, str] = creationUrls
         self._management_urls: Dict[str, str] = managementUrls
-        # TODO: we can remove the Optional once we drop support for 1.x, this is always provided in 2.x
+        # TODO: we can remove the Optional once we drop support for 1.x,
+        # this is always provided in 2.x
         self._rpc_base_url: Optional[str] = rpcBaseUrl
         self._client_data = FunctionContext(**kwargs)
 

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -32,6 +32,7 @@ class DurableOrchestrationContext:
         self._custom_status: Any = None
         self._new_uuid_counter: int = 0
         self._sub_orchestrator_counter: int = 0
+        self._continue_as_new_flag: bool = False
         self.call_activity = lambda n, i=None: call_activity_task(
             state=self.histories,
             name=n,
@@ -65,7 +66,7 @@ class DurableOrchestrationContext:
             state=self.histories,
             name=n)
         self.new_uuid = lambda: new_uuid(context=self)
-        self.continue_as_new = lambda i: continue_as_new(input_=i)
+        self.continue_as_new = lambda i: continue_as_new(context=self, input_=i)
         self.task_any = lambda t: task_any(tasks=t)
         self.task_all = lambda t: task_all(tasks=t)
         self.create_timer = lambda d: create_timer_task(state=self.histories, fire_at=d)
@@ -344,3 +345,8 @@ class DurableOrchestrationContext:
             Object containing function level attributes not used by durable orchestrator.
         """
         return self._function_context
+
+    @property
+    def will_continue_as_new(self) -> bool:
+        """Return true if continue_as_new was called."""
+        return self._continue_as_new_flag

--- a/azure/durable_functions/models/DurableOrchestrationStatus.py
+++ b/azure/durable_functions/models/DurableOrchestrationStatus.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from dateutil.parser import parse as dt_parse
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional, Union
 
-from .OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 from .utils.json_utils import add_attrib, add_datetime_attrib
 
 
@@ -13,20 +12,23 @@ class DurableOrchestrationStatus:
     """
 
     # parameter names are as defined by JSON schema and do not conform to PEP8 naming conventions
-    def __init__(self, name: str = None, instanceId: str = None, createdTime: str = None,
-                 lastUpdatedTime: str = None, input: Any = None, output: Any = None,
-                 runtimeStatus: str = None, customStatus: Any = None, history: List[Any] = None,
+    def __init__(self, name: Optional[str] = None, instanceId: Optional[str] = None,
+                 createdTime: Optional[str] = None, lastUpdatedTime: Optional[str] = None,
+                 input: Optional[Any] = None, output: Optional[Any] = None,
+                 runtimeStatus: Optional[str] = None, customStatus: Optional[Any] = None,
+                 history: Optional[List[Any]] = None,
                  **kwargs):
-        self._name: str = name
-        self._instance_id: str = instanceId
-        self._created_time: datetime = dt_parse(createdTime) if createdTime is not None else None
-        self._last_updated_time: datetime = dt_parse(lastUpdatedTime) \
+        self._name: Optional[str] = name
+        self._instance_id: Optional[str] = instanceId
+        self._created_time: Optional[datetime] = \
+            dt_parse(createdTime) if createdTime is not None else None
+        self._last_updated_time: Optional[datetime] = dt_parse(lastUpdatedTime) \
             if lastUpdatedTime is not None else None
         self._input: Any = input
         self._output: Any = output
-        self._runtime_status: OrchestrationRuntimeStatus = runtimeStatus
+        self._runtime_status: Optional[str] = runtimeStatus  # TODO: GH issue 178
         self._custom_status: Any = customStatus
-        self._history: List[Any] = history
+        self._history: Optional[List[Any]] = history
         if kwargs is not None:
             for key, value in kwargs.items():
                 self.__setattr__(key, value)
@@ -65,15 +67,15 @@ class DurableOrchestrationStatus:
         else:
             return cls(**json_obj)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[int, str]]:
         """Convert object into a json dictionary.
 
         Returns
         -------
-        Dict[str, Any]
+        Dict[str, Union[int, str]]
             The instance of the class converted into a json dictionary
         """
-        json = {}
+        json: Dict[str, Union[int, str]] = {}
         add_attrib(json, self, 'name')
         add_attrib(json, self, 'instance_id', 'instanceId')
         add_datetime_attrib(json, self, 'created_time', 'createdTime')
@@ -86,12 +88,12 @@ class DurableOrchestrationStatus:
         return json
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         """Get the orchestrator function name."""
         return self._name
 
     @property
-    def instance_id(self) -> str:
+    def instance_id(self) -> Optional[str]:
         """Get the unique ID of the instance.
 
         The instance ID is generated and fixed when the orchestrator
@@ -102,7 +104,7 @@ class DurableOrchestrationStatus:
         return self._instance_id
 
     @property
-    def created_time(self) -> datetime:
+    def created_time(self) -> Optional[datetime]:
         """Get the time at which the orchestration instance was created.
 
         If the orchestration instance is in the [[Pending]] status, this
@@ -112,7 +114,7 @@ class DurableOrchestrationStatus:
         return self._created_time
 
     @property
-    def last_updated_time(self) -> datetime:
+    def last_updated_time(self) -> Optional[datetime]:
         """Get the time at which the orchestration instance last updated its execution history."""
         return self._last_updated_time
 
@@ -127,7 +129,7 @@ class DurableOrchestrationStatus:
         return self._output
 
     @property
-    def runtime_status(self) -> OrchestrationRuntimeStatus:
+    def runtime_status(self) -> Optional[str]:
         """Get the runtime status of the orchestration instance."""
         return self._runtime_status
 
@@ -140,7 +142,7 @@ class DurableOrchestrationStatus:
         return self._custom_status
 
     @property
-    def history(self) -> List[Any]:
+    def history(self) -> Optional[List[Any]]:
         """Get the execution history of the orchestration instance.
 
         The history log can be large and is therefore `undefined` by

--- a/azure/durable_functions/models/OrchestratorState.py
+++ b/azure/durable_functions/models/OrchestratorState.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Optional, Union
 
 from .utils.json_utils import add_attrib
 from azure.durable_functions.models.actions.Action import Action
@@ -21,7 +21,7 @@ class OrchestratorState:
         self._is_done: bool = is_done
         self._actions: List[List[Action]] = actions
         self._output: Any = output
-        self._error: str = error
+        self._error: Optional[str] = error
         self._custom_status: Any = custom_status
 
     @property
@@ -54,7 +54,7 @@ class OrchestratorState:
         return self._output
 
     @property
-    def error(self) -> str:
+    def error(self) -> Optional[str]:
         """Get the error received when running the orchestration.
 
         Optional.
@@ -66,7 +66,7 @@ class OrchestratorState:
         """Get the JSON-serializable value used by DurableOrchestrationContext.SetCustomStatus."""
         return self._custom_status
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
@@ -74,7 +74,7 @@ class OrchestratorState:
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, '_is_done', 'isDone')
         self._add_actions(json_dict)
         if not (self._output is None):

--- a/azure/durable_functions/models/PurgeHistoryResult.py
+++ b/azure/durable_functions/models/PurgeHistoryResult.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Dict, Any
 
 
 class PurgeHistoryResult:
@@ -12,12 +12,12 @@ class PurgeHistoryResult:
                 self.__setattr__(key, value)
 
     @classmethod
-    def from_json(cls, json_obj: Any):
+    def from_json(cls, json_obj: Dict[Any, Any]):
         """Convert the value passed into a new instance of the class.
 
         Parameters
         ----------
-        json_obj: any
+        json_obj: Dict[Any, Any]
             JSON object to be converted into an instance of the class
 
         Returns
@@ -25,10 +25,7 @@ class PurgeHistoryResult:
         PurgeHistoryResult
             New instance of the durable orchestration status class
         """
-        if isinstance(json_obj, str):
-            return cls(message=json_obj)
-        else:
-            return cls(**json_obj)
+        return cls(**json_obj)
 
     @property
     def instances_deleted(self):

--- a/azure/durable_functions/models/RetryOptions.py
+++ b/azure/durable_functions/models/RetryOptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict, Union
 
 from .utils.json_utils import add_attrib
 
@@ -46,7 +46,7 @@ class RetryOptions:
         """
         return self._max_number_of_attempts
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
@@ -54,7 +54,7 @@ class RetryOptions:
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
 
         add_attrib(
             json_dict,

--- a/azure/durable_functions/models/RpcManagementOptions.py
+++ b/azure/durable_functions/models/RpcManagementOptions.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any, List, Optional
 
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
 from azure.durable_functions.models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
@@ -29,12 +29,12 @@ class RpcManagementOptions:
             query.append(f'{name}={value}')
 
     @staticmethod
-    def _add_date_arg(query: List[str], name: str, value: datetime):
+    def _add_date_arg(query: List[str], name: str, value: Optional[datetime]):
         if value:
             date_as_string = value.strftime(DATETIME_STRING_FORMAT)
             RpcManagementOptions._add_arg(query, name, date_as_string)
 
-    def to_url(self, base_url: str) -> str:
+    def to_url(self, base_url: Optional[str]) -> str:
         """Get the url based on the options selected.
 
         Parameters
@@ -42,14 +42,22 @@ class RpcManagementOptions:
         base_url: str
             The base url to prepend to the url path
 
+        Raises
+        ------
+        ValueError
+            When the `base_url` argument is None
+
         Returns
         -------
         str
             The Url used to get orchestration status information
         """
+        if base_url is None:
+            raise ValueError("orchestration bindings has not RPC base url")
+
         url = f"{base_url}instances/{self._instance_id if self._instance_id else ''}"
 
-        query = []
+        query: List[str] = []
 
         self._add_arg(query, 'taskHub', self._task_hub_name)
         self._add_arg(query, 'connectionName', self._connection_name)

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from .actions import Action
+from .actions.Action import Action
 
 
 class Task:

--- a/azure/durable_functions/models/TokenSource.py
+++ b/azure/durable_functions/models/TokenSource.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Dict, Any
+from typing import Dict, Union
 
 from azure.durable_functions.models.utils.json_utils import add_attrib
 
@@ -41,7 +41,7 @@ class ManagedIdentityTokenSource(TokenSource):
         """
         return self._resource
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
@@ -49,6 +49,6 @@ class ManagedIdentityTokenSource(TokenSource):
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'resource')
         return json_dict

--- a/azure/durable_functions/models/actions/CallActivityAction.py
+++ b/azure/durable_functions/models/actions/CallActivityAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict, Union
 
 from .Action import Action
 from .ActionType import ActionType
@@ -26,15 +26,15 @@ class CallActivityAction(Action):
         """Get the type of action this class represents."""
         return ActionType.CALL_ACTIVITY
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
         -------
-        Dict[str, Any]
+        Dict[str, Union[str, int]]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_attrib(json_dict, self, 'function_name', 'functionName')
         add_attrib(json_dict, self, 'input_', 'input')

--- a/azure/durable_functions/models/actions/CallActivityWithRetryAction.py
+++ b/azure/durable_functions/models/actions/CallActivityWithRetryAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict, Union
 
 from .Action import Action
 from .ActionType import ActionType
@@ -26,15 +26,15 @@ class CallActivityWithRetryAction(Action):
         """Get the type of action this class represents."""
         return ActionType.CALL_ACTIVITY_WITH_RETRY
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[str, int]]:
         """Convert object into a json dictionary.
 
         Returns
         -------
-        Dict[str, Any]
+        Dict[str, Union[str, int]]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
 
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_attrib(json_dict, self, 'function_name', 'functionName')

--- a/azure/durable_functions/models/actions/CallHttpAction.py
+++ b/azure/durable_functions/models/actions/CallHttpAction.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from .Action import Action
 from .ActionType import ActionType
-from .. import DurableHttpRequest
+from ..DurableHttpRequest import DurableHttpRequest
 from ..utils.json_utils import add_attrib, add_json_attrib
 
 
@@ -29,7 +29,7 @@ class CallHttpAction(Action):
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Any] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_json_attrib(json_dict, self, 'http_request', 'httpRequest')
         return json_dict

--- a/azure/durable_functions/models/actions/CallSubOrchestratorAction.py
+++ b/azure/durable_functions/models/actions/CallSubOrchestratorAction.py
@@ -10,10 +10,11 @@ from azure.functions._durable_functions import _serialize_custom_object
 class CallSubOrchestratorAction(Action):
     """Defines the structure of the Call SubOrchestrator object."""
 
-    def __init__(self, function_name: str, _input: Optional[Any] = None, instance_id: str = ""):
+    def __init__(self, function_name: str, _input: Optional[Any] = None,
+                 instance_id: Optional[str] = None):
         self.function_name: str = function_name
         self._input: str = dumps(_input, default=_serialize_custom_object)
-        self.instance_id: str = instance_id
+        self.instance_id: Optional[str] = instance_id
 
         if not self.function_name:
             raise ValueError("function_name cannot be empty")

--- a/azure/durable_functions/models/actions/CallSubOrchestratorWithRetryAction.py
+++ b/azure/durable_functions/models/actions/CallSubOrchestratorWithRetryAction.py
@@ -13,11 +13,11 @@ class CallSubOrchestratorWithRetryAction(Action):
 
     def __init__(self, function_name: str, retry_options: RetryOptions,
                  _input: Optional[Any] = None,
-                 instance_id: str = ""):
+                 instance_id: Optional[str] = None):
         self.function_name: str = function_name
         self._input: str = dumps(_input, default=_serialize_custom_object)
         self.retry_options: RetryOptions = retry_options
-        self.instance_id: str = instance_id
+        self.instance_id: Optional[str] = instance_id
 
         if not self.function_name:
             raise ValueError("function_name cannot be empty")

--- a/azure/durable_functions/models/actions/ContinueAsNewAction.py
+++ b/azure/durable_functions/models/actions/ContinueAsNewAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Dict, Union
 
 from .Action import Action
 from .ActionType import ActionType
@@ -20,7 +20,7 @@ class ContinueAsNewAction(Action):
         """Get the type of action this class represents."""
         return ActionType.CONTINUE_AS_NEW
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> Dict[str, Union[int, str]]:
         """Convert object into a json dictionary.
 
         Returns
@@ -28,7 +28,7 @@ class ContinueAsNewAction(Action):
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[int, str]] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_attrib(json_dict, self, 'input_', 'input')
         return json_dict

--- a/azure/durable_functions/models/actions/CreateTimerAction.py
+++ b/azure/durable_functions/models/actions/CreateTimerAction.py
@@ -1,11 +1,12 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from .ActionType import ActionType
+from .Action import Action
 from ..utils.json_utils import add_attrib, add_datetime_attrib
 import datetime
 
 
-class CreateTimerAction:
+class CreateTimerAction(Action):
     """Defines the structure of the Create Timer object.
 
     Returns
@@ -18,9 +19,9 @@ class CreateTimerAction:
         if the event fired is not of valid datetime object
     """
 
-    def __init__(self, fire_at: datetime, is_cancelled: bool = False):
-        self.action_type: ActionType = ActionType.CREATE_TIMER
-        self.fire_at: datetime = fire_at
+    def __init__(self, fire_at: datetime.datetime, is_cancelled: bool = False):
+        self._action_type: ActionType = ActionType.CREATE_TIMER
+        self.fire_at: datetime.datetime = fire_at
         self.is_cancelled: bool = is_cancelled
 
         if not isinstance(self.fire_at, datetime.date):
@@ -35,8 +36,13 @@ class CreateTimerAction:
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[int, str]] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_datetime_attrib(json_dict, self, 'fire_at', 'fireAt')
         add_attrib(json_dict, self, 'is_cancelled', 'isCanceled')
         return json_dict
+
+    @property
+    def action_type(self) -> int:
+        """Get the type of action this class represents."""
+        return ActionType.CREATE_TIMER

--- a/azure/durable_functions/models/actions/WaitForExternalEventAction.py
+++ b/azure/durable_functions/models/actions/WaitForExternalEventAction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from .Action import Action
 from .ActionType import ActionType
@@ -36,10 +36,10 @@ class WaitForExternalEventAction(Action):
 
         Returns
         -------
-        Dict[str, Any]
+        Dict[str, Union[str, int]]
             The instance of the class converted into a json dictionary
         """
-        json_dict = {}
+        json_dict: Dict[str, Union[str, int]] = {}
 
         add_attrib(json_dict, self, 'action_type', 'actionType')
         add_attrib(json_dict, self, 'external_event_name', 'externalEventName')

--- a/azure/durable_functions/models/history/HistoryEvent.py
+++ b/azure/durable_functions/models/history/HistoryEvent.py
@@ -12,7 +12,7 @@ class HistoryEvent:
         self._event_type: HistoryEventType = EventType
         self._event_id: int = EventId
         self._is_played: bool = IsPlayed
-        self._timestamp: datetime = dt_parse(Timestamp)
+        self._timestamp: datetime.datetime = dt_parse(Timestamp)
         self._is_processed: bool = False
         if kwargs is not None:
             for key, value in kwargs.items():
@@ -74,7 +74,7 @@ class HistoryEvent:
         self._is_processed = value
 
     @property
-    def timestamp(self) -> datetime:
+    def timestamp(self) -> datetime.datetime:
         """Get the timestamp property.
 
         Returns

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Any, List, Union
 
 import aiohttp
 
 
-async def post_async_request(url: str, data: Any = None) -> [int, Any]:
+async def post_async_request(url: str, data: Any = None) -> List[Union[int, Any]]:
     """Post request with the data provided to the url provided.
 
     Parameters
@@ -29,7 +29,7 @@ async def post_async_request(url: str, data: Any = None) -> [int, Any]:
             return [response.status, data]
 
 
-async def get_async_request(url: str) -> [int, Any]:
+async def get_async_request(url: str) -> List[Any]:
     """Get the data from the url provided.
 
     Parameters
@@ -50,7 +50,7 @@ async def get_async_request(url: str) -> [int, Any]:
             return [response.status, data]
 
 
-async def delete_async_request(url: str) -> [int, Any]:
+async def delete_async_request(url: str) -> List[Union[int, Any]]:
     """Delete the data from the url provided.
 
     Parameters

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -49,57 +49,66 @@ class Orchestrator:
         suspended = False
 
         fn_output = self.fn(self.durable_context)
+
         # If `fn_output` is not an Iterator, then the orchestrator
         # function does not make use of its context parameter. If so,
         # `fn_output` is the return value instead of a generator
-        if isinstance(fn_output, Iterator):
-            self.generator = fn_output
-
-        else:
+        if not isinstance(fn_output, Iterator):
             orchestration_state = OrchestratorState(
                 is_done=True,
                 output=fn_output,
                 actions=self.durable_context.actions,
                 custom_status=self.durable_context.custom_status)
-            return orchestration_state.to_json_string()
-        try:
-            generation_state = self._generate_next(None)
 
-            while not suspended:
-                self._add_to_actions(generation_state)
+        else:
+            self.generator = fn_output
+            try:
+                generation_state = self._generate_next(None)
 
-                if should_suspend(generation_state):
-                    orchestration_state = OrchestratorState(
-                        is_done=False,
-                        output=None,
-                        actions=self.durable_context.actions,
-                        custom_status=self.durable_context.custom_status)
-                    suspended = True
-                    continue
+                while not suspended:
+                    self._add_to_actions(generation_state)
 
-                if (isinstance(generation_state, Task)
-                    or isinstance(generation_state, TaskSet)) and (
-                        generation_state.is_faulted):
-                    generation_state = self.generator.throw(
-                        generation_state.exception)
-                    continue
+                    if should_suspend(generation_state):
 
-                self._reset_timestamp()
-                generation_state = self._generate_next(generation_state)
+                        # The `is_done` field should be False here unless
+                        # `continue_as_new` was called. Therefore,
+                        # `will_continue_as_new` essentially "tracks"
+                        # whether or not the orchestration is done.
+                        orchestration_state = OrchestratorState(
+                            is_done=self.durable_context.will_continue_as_new,
+                            output=None,
+                            actions=self.durable_context.actions,
+                            custom_status=self.durable_context.custom_status)
+                        suspended = True
+                        continue
 
-        except StopIteration as sie:
-            orchestration_state = OrchestratorState(
-                is_done=True,
-                output=sie.value,
-                actions=self.durable_context.actions,
-                custom_status=self.durable_context.custom_status)
-        except Exception as e:
-            orchestration_state = OrchestratorState(
-                is_done=False,
-                output=None,  # Should have no output, after generation range
-                actions=self.durable_context.actions,
-                error=str(e),
-                custom_status=self.durable_context.custom_status)
+                    if (isinstance(generation_state, Task)
+                        or isinstance(generation_state, TaskSet)) and (
+                            generation_state.is_faulted):
+                        generation_state = self.generator.throw(
+                            generation_state.exception)
+                        continue
+
+                    self._reset_timestamp()
+                    generation_state = self._generate_next(generation_state)
+
+            except StopIteration as sie:
+                orchestration_state = OrchestratorState(
+                    is_done=True,
+                    output=sie.value,
+                    actions=self.durable_context.actions,
+                    custom_status=self.durable_context.custom_status)
+            except Exception as e:
+                orchestration_state = OrchestratorState(
+                    is_done=False,
+                    output=None,  # Should have no output, after generation range
+                    actions=self.durable_context.actions,
+                    error=str(e),
+                    custom_status=self.durable_context.custom_status)
+
+        # No output if continue_as_new was called
+        if self.durable_context.will_continue_as_new:
+            orchestration_state._output = None
 
         return orchestration_state.to_json_string()
 
@@ -108,9 +117,13 @@ class Orchestrator:
             gen_result = self.generator.send(partial_result.result)
         else:
             gen_result = self.generator.send(None)
+
         return gen_result
 
     def _add_to_actions(self, generation_state):
+        # Do not add new tasks to action if continue_as_new was called
+        if self.durable_context.will_continue_as_new:
+            return
         if (isinstance(generation_state, Task)
                 and hasattr(generation_state, "action")):
             self.durable_context.actions.append([generation_state.action])

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -3,7 +3,7 @@
 Responsible for orchestrating the execution of the user defined generator
 function.
 """
-from typing import Callable, Iterator, Any
+from typing import Callable, Iterator, Any, Generator
 
 from .models import (
     DurableOrchestrationContext,
@@ -24,14 +24,14 @@ class Orchestrator:
     """
 
     def __init__(self,
-                 activity_func: Callable[[DurableOrchestrationContext], Iterator[Any]]):
+                 activity_func: Callable[[DurableOrchestrationContext], Generator[Any, Any, Any]]):
         """Create a new orchestrator for the user defined generator.
 
         Responsible for orchestrating the execution of the user defined
         generator function.
         :param activity_func: Generator function to orchestrate.
         """
-        self.fn: Callable[[DurableOrchestrationContext], Iterator[Any]] = activity_func
+        self.fn: Callable[[DurableOrchestrationContext], Generator[Any, Any, Any]] = activity_func
 
     def handle(self, context: DurableOrchestrationContext):
         """Handle the orchestration of the user defined generator function.
@@ -145,7 +145,7 @@ class Orchestrator:
                 self.durable_context.decision_started_event.timestamp
 
     @classmethod
-    def create(cls, fn: Callable[[DurableOrchestrationContext], Iterator[Any]]) \
+    def create(cls, fn: Callable[[DurableOrchestrationContext], Generator[Any, Any, Any]]) \
             -> Callable[[Any], str]:
         """Create an instance of the orchestration class.
 

--- a/azure/durable_functions/tasks/call_http.py
+++ b/azure/durable_functions/tasks/call_http.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .task_utilities import find_task_scheduled, find_task_completed, find_task_failed, \
     set_processed, parse_history_event
@@ -12,8 +12,8 @@ from ..models.Task import (
     Task)
 
 
-def call_http(state: List[HistoryEvent], method: str, uri: str, content: str = None,
-              headers: Dict[str, str] = None, token_source: TokenSource = None) -> Task:
+def call_http(state: List[HistoryEvent], method: str, uri: str, content: Optional[str] = None,
+              headers: Dict[str, str] = None, token_source: Optional[TokenSource] = None) -> Task:
     """Get task used to schedule a durable HTTP call to the specified endpoint.
 
     Parameters
@@ -37,6 +37,7 @@ def call_http(state: List[HistoryEvent], method: str, uri: str, content: str = N
     Task
         The durable HTTP request to schedule.
     """
+    json_content: Optional[str] = None
     if content and content is not isinstance(content, str):
         json_content = json.dumps(content)
     else:

--- a/azure/durable_functions/tasks/call_suborchestrator.py
+++ b/azure/durable_functions/tasks/call_suborchestrator.py
@@ -14,7 +14,7 @@ def call_sub_orchestrator_task(
         state: List[HistoryEvent],
         name: str,
         input_: Optional[Any] = None,
-        instance_id: str = "") -> Task:
+        instance_id: Optional[str] = None) -> Task:
     """Determine the state of Scheduling a sub-orchestrator for execution.
 
     Parameters

--- a/azure/durable_functions/tasks/call_suborchestrator_with_retry.py
+++ b/azure/durable_functions/tasks/call_suborchestrator_with_retry.py
@@ -16,7 +16,7 @@ def call_sub_orchestrator_with_retry_task(
         retry_options: RetryOptions,
         name: str,
         input_: Optional[Any] = None,
-        instance_id: str = "") -> Task:
+        instance_id: Optional[str] = None) -> Task:
     """Determine the state of Scheduling a sub-orchestrator for execution, with retry options.
 
     Parameters

--- a/azure/durable_functions/tasks/continue_as_new.py
+++ b/azure/durable_functions/tasks/continue_as_new.py
@@ -1,24 +1,19 @@
 from typing import Any
 
-from ..models.Task import (
-    Task)
 from ..models.actions.ContinueAsNewAction import ContinueAsNewAction
 
 
 def continue_as_new(
-        input_: Any = None) -> Task:
+        context,
+        input_: Any = None):
     """Create a new continue as new action.
 
     Parameters
     ----------
     input_: Any
         The JSON-serializable input to pass to the activity function.
-
-    Returns
-    -------
-    Task
-        A Durable Task that causes the orchestrator reset and start as a new orchestration.
     """
     new_action = ContinueAsNewAction(input_)
 
-    return Task(is_completed=False, is_faulted=False, action=new_action)
+    context.actions.append([new_action])
+    context._continue_as_new_flag = True

--- a/azure/durable_functions/tasks/create_timer.py
+++ b/azure/durable_functions/tasks/create_timer.py
@@ -7,7 +7,7 @@ from .timer_task import TimerTask
 
 
 def create_timer_task(state: List[HistoryEvent],
-                      fire_at: datetime) -> TimerTask:
+                      fire_at: datetime.datetime) -> TimerTask:
     """Durable Timers are used in orchestrator function to implement delays.
 
     Parameters

--- a/azure/durable_functions/tasks/new_uuid.py
+++ b/azure/durable_functions/tasks/new_uuid.py
@@ -1,7 +1,11 @@
 from uuid import uuid5, NAMESPACE_OID
 
-from azure.durable_functions.models import DurableOrchestrationContext
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
+import typing
+
+if typing.TYPE_CHECKING:
+    from azure.durable_functions.models.DurableOrchestrationContext \
+        import DurableOrchestrationContext
 
 URL_NAMESPACE: str = "9e952958-5e33-4daf-827f-2fa12937b875"
 
@@ -11,7 +15,7 @@ def _create_deterministic_uuid(namespace_value: str, name: str) -> str:
     return str(uuid5(namespace_uuid, name))
 
 
-def new_uuid(context: DurableOrchestrationContext) -> str:
+def new_uuid(context: 'DurableOrchestrationContext') -> str:
     """Create a new UUID that is safe for replay within an orchestration or operation.
 
     The default implementation of this method creates a name-based UUID
@@ -31,7 +35,7 @@ def new_uuid(context: DurableOrchestrationContext) -> str:
         New UUID that is safe for replay within an orchestration or operation.
     """
     uuid_name_value = \
-        f"{context.instance_id}" \
+        f"{context._instance_id}" \
         f"_{context.current_utc_datetime.strftime(DATETIME_STRING_FORMAT)}" \
         f"_{context._new_uuid_counter}"
     context._new_uuid_counter += 1

--- a/azure/durable_functions/tasks/task_utilities.py
+++ b/azure/durable_functions/tasks/task_utilities.py
@@ -199,7 +199,7 @@ def set_processed(tasks):
 
 
 def find_sub_orchestration(
-        state: List[HistoryEventType],
+        state: List[HistoryEvent],
         event_type: HistoryEventType,
         name: Optional[str] = None,
         context=None,
@@ -209,11 +209,11 @@ def find_sub_orchestration(
 
     Parameters
     ----------
-    state: List[HistoryEventType]
+    state: List[HistoryEvent]
         The history of Durable events
     event_type: HistoryEventType
         The type of Durable event to look for.
-    name: str:
+    name: Optional[str]:
         Name of the sub-orchestrator.
     context: Optional['DurableOrchestrationContext']
         A reference to the orchestration context
@@ -246,30 +246,35 @@ def find_sub_orchestration(
         context._sub_orchestrator_counter += 1
         counter: int = context._sub_orchestrator_counter
 
+        if name is None:
+            err = "Tried to lookup suborchestration in history but had not name to reference it."
+            raise ValueError(err)
+
         # TODO: The HistoryEvent does not necessarily have an name or an instance_id
         #       We should create sub-classes of these types like JS does
+        err_message: str = ""
         if not(event.Name == name):
             mid_message = "a function name of {} instead of the provided function name of {}."
-            err_message: str = gen_err_message(counter, mid_message, event.name, name)
+            err_message = gen_err_message(counter, mid_message, event.Name, name)
             raise ValueError(err_message)
         if instance_id and not(event.InstanceId == instance_id):
             mid_message = "an instance id of {} instead of the provided instance id of {}."
-            err_message: str = gen_err_message(counter, mid_message, event.name, name)
+            err_message = gen_err_message(counter, mid_message, event.Name, name)
             raise ValueError(err_message)
 
     return event
 
 
 def find_sub_orchestration_created(
-        state: List[HistoryEventType],
+        state: List[HistoryEvent],
         name: str,
         context=None,
-        instance_id: Optional[str] = None) -> Optional[HistoryEventType]:
+        instance_id: Optional[str] = None) -> Optional[HistoryEvent]:
     """Look-up matching sub-orchestrator created event in the state array.
 
     Parameters
     ----------
-    state: List[HistoryEventType]:
+    state: List[HistoryEvent]:
         The history of Durable events
     name: str:
         Name of the sub-orchestrator.
@@ -285,7 +290,7 @@ def find_sub_orchestration_created(
 
     Returns
     -------
-    Optional[HistoryEventType]:
+    Optional[HistoryEvent]:
         The matching sub-orchestration creation event. Else, None.
     """
     event_type = HistoryEventType.SUB_ORCHESTRATION_INSTANCE_CREATED
@@ -298,20 +303,20 @@ def find_sub_orchestration_created(
 
 
 def find_sub_orchestration_completed(
-        state: List[HistoryEventType],
-        scheduled_task: Optional[HistoryEventType]) -> Optional[HistoryEventType]:
+        state: List[HistoryEvent],
+        scheduled_task: Optional[HistoryEvent]) -> Optional[HistoryEvent]:
     """Look-up the sub-orchestration completed event.
 
     Parameters
     ----------
-    state: List[HistoryEventType]:
+    state: List[HistoryEvent]:
         The history of Durable events
-    scheduled_task: Optional[HistoryEventType]:
+    scheduled_task: Optional[HistoryEvent]:
         The sub-orchestration creation event, if found.
 
     Returns
     -------
-    Optional[HistoryEventType]:
+    Optional[HistoryEvent]:
         The matching sub-orchestration completed event, if found. Else, None.
     """
     event_type = HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED
@@ -395,8 +400,7 @@ def find_matching_event(
     event: Optional[HistoryEvent] = None
 
     # Preverse only the elements of the state array that correspond with the looked-up event
-    matches = filter(should_preserve, state)
-    matches = list(matches)
+    matches = list(filter(should_preserve, state))
 
     if len(matches) >= 1:
         # TODO: in many instances, `matches` will be greater than 1 in length. We take the
@@ -404,5 +408,5 @@ def find_matching_event(
         # we assume corresponds to the one we are looking for. This may be brittle but
         # is true about other areas of the code as well such as with `call_activity`.
         # We should try to refactor this logic at some point
-        event: HistoryEventType = matches[0]
+        event = matches[0]
     return event

--- a/azure/durable_functions/tasks/timer_task.py
+++ b/azure/durable_functions/tasks/timer_task.py
@@ -1,4 +1,5 @@
 from ..models.Task import Task
+from ..models.actions.CreateTimerAction import CreateTimerAction
 
 
 class TimerTask(Task):
@@ -14,8 +15,8 @@ class TimerTask(Task):
     ```
     """
 
-    def __init__(self, action, is_completed, timestamp, id_):
-        self._action = action
+    def __init__(self, action: CreateTimerAction, is_completed, timestamp, id_):
+        self._action: CreateTimerAction = action
         self._is_completed = is_completed
         self._timestamp = timestamp
         self._id = id_

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-@nox.session(python="3.7")
+@nox.session(python=["3.7","3.8"])
 def tests(session):
     # same as pip install -r -requirements.txt
     session.install("-r", "requirements.txt")
@@ -8,8 +8,13 @@ def tests(session):
     session.run("pytest", "-v", "tests")
 
 
-@nox.session(python="3.7")
+@nox.session(python=["3.7", "3.8"])
 def lint(session):
     session.install("flake8")
     session.install("flake8-docstrings")
     session.run("flake8", "./azure/")
+
+@nox.session(python=["3.7", "3.8"])
+def typecheck(session):
+    session.install("mypy")
+    session.run("mypy", "./azure/")

--- a/tests/orchestrator/test_continue_as_new.py
+++ b/tests/orchestrator/test_continue_as_new.py
@@ -10,7 +10,7 @@ from azure.durable_functions.models.actions.ContinueAsNewAction \
 
 def generator_function(context):
     yield context.call_activity("Hello", "Tokyo")
-    yield context.continue_as_new("Cause I can")
+    context.continue_as_new("Cause I can")
 
 
 def base_expected_state(output=None) -> OrchestratorState:
@@ -25,6 +25,7 @@ def add_hello_action(state: OrchestratorState, input_: str):
 def add_continue_as_new_action(state: OrchestratorState, input_: str):
     action = ContinueAsNewAction(input_=input_)
     state.actions.append([action])
+    state._is_done = True
 
 
 def add_hello_completed_events(


### PR DESCRIPTION
_Well typed programs don't go wrong ...._

**Do not merge yet,** I want to double check with some of our internal Python experts if our use of the `Optional` type hint, and type aliasing is idiomatic. **However, feel free to review**

This PR constitutes, to the best of my knowledge, the first type-checking of our codebase. As per the `mypy` type-checker, our codebase is type-safe and. Most of the work required to get there revolved around acknowledging and guarding against the `None` types that flow through our code. In fact, after this effort, I'm really concerned about the amount of `None` initialization that we do in our codebase. As a result, I'd love to speak with some of our internal Python experts about providing sane initialization values to non-object types. Especially because initializing all optional values as `None` is, on the flipside, very convenient for guarding against them.

Something else I attempt in this PR, although very minimally, is the idea of introducing `type aliases` to provide more information around primitive types. For instance, many functions returns URL-formatted strings and thus the return type of `str` is not very informative, in my opinion. In languages like Haskell, it's common to alias these types to better document functions, therefore resulting in an aliasing of `str` to a new name like `URLstr`. I have yet to figure out how _pythonic_ that really is. In this PR, I uses a type alias for `Any` called `SerializableToJSON` in hopes of conveying that some inputs can be of any type so long as they're serializable. Again, I need to check with an expert if this is idiomatic. If so, I'll propagate the `SerializableToJSON` datatype all over the codebase