### PR TITLE
Improved datetime comparison logic

### DIFF
--- a/azure/durable_functions/tasks/task_utilities.py
+++ b/azure/durable_functions/tasks/task_utilities.py
@@ -131,7 +131,8 @@ def find_task_timer_created(state, fire_at):
     if fire_at is None:
         return None
 
-    # We remove the timezone metadata, to enable comparisons with timezone-naive datetime objects. This may be dangerous
+    # We remove the timezone metadata,
+    # to enable comparisons with timezone-naive datetime objects. This may be dangerous
     fire_at = fire_at.replace(tzinfo=None)
     tasks = []
     for e in state:

--- a/azure/durable_functions/tasks/task_utilities.py
+++ b/azure/durable_functions/tasks/task_utilities.py
@@ -2,6 +2,7 @@ import json
 from ..models.history import HistoryEventType
 from ..constants import DATETIME_STRING_FORMAT
 from azure.functions._durable_functions import _deserialize_custom_object
+from datetime import datetime
 
 
 def should_suspend(partial_result) -> bool:
@@ -130,10 +131,12 @@ def find_task_timer_created(state, fire_at):
     if fire_at is None:
         return None
 
+    # We remove the timezone metadata, to enable comparisons with timezone-naive datetime objects. This may be dangerous
+    fire_at = fire_at.replace(tzinfo=None)
     tasks = []
     for e in state:
         if e.event_type == HistoryEventType.TIMER_CREATED and hasattr(e, "FireAt"):
-            if e.FireAt == fire_at.strftime(DATETIME_STRING_FORMAT):
+            if datetime.strptime(e.FireAt, DATETIME_STRING_FORMAT) == fire_at:
                 tasks.append(e)
 
     if len(tasks) == 0:

--- a/tests/orchestrator/test_create_timer.py
+++ b/tests/orchestrator/test_create_timer.py
@@ -1,0 +1,66 @@
+from tests.test_utils.ContextBuilder import ContextBuilder
+from .orchestrator_test_utils \
+    import get_orchestration_state_result, assert_orchestration_state_equals, assert_valid_schema
+from azure.durable_functions.models.actions.CreateTimerAction import CreateTimerAction
+from azure.durable_functions.models.OrchestratorState import OrchestratorState
+from azure.durable_functions.constants import DATETIME_STRING_FORMAT
+from datetime import datetime, timedelta, timezone
+
+
+def base_expected_state(output=None) -> OrchestratorState:
+    return OrchestratorState(is_done=False, actions=[], output=output)
+
+def add_timer_fired_events(context_builder: ContextBuilder, id_: int, timestamp: str):
+    fire_at: str = context_builder.add_timer_created_event(id_, timestamp)
+    context_builder.add_orchestrator_completed_event()
+    context_builder.add_orchestrator_started_event()
+    context_builder.add_timer_fired_event(id_=id_, fire_at=fire_at)
+
+def generator_function(context):
+
+    # Create a timezone aware datetime object, just like a normal
+    # call to `context.current_utc_datetime` would create
+    timestamp = "2020-07-23T21:56:54.936700Z"
+    fire_at = datetime.strptime(timestamp, DATETIME_STRING_FORMAT)
+    fire_at = fire_at.replace(tzinfo=timezone.utc)
+
+    yield context.create_timer(fire_at)
+    return "Done!"
+
+def add_timer_action(state: OrchestratorState, fire_at: datetime):
+    action = CreateTimerAction(fire_at= fire_at)
+    state._actions.append([action]) # Todo: brackets?
+
+def test_timers_comparison_with_relaxed_precision():
+    """Test if that two `datetime` different but equivalent
+    serializations of timer deadlines are found to be equivalent.
+
+    The Durable Extension may sometimes drop redundant zeroes on
+    a datetime object. For instance, the date
+        2020-07-23T21:56:54.936700Z
+    may get transformed into
+        2020-07-23T21:56:54.9367Z
+    This test ensures that dropping redundant zeroes does not affect
+    our ability to recognize that a timer has been fired.
+    """
+
+    # equivalent to 2020-07-23T21:56:54.936700Z
+    relaxed_timestamp = "2020-07-23T21:56:54.9367Z"
+    fire_at = datetime.strptime(relaxed_timestamp, DATETIME_STRING_FORMAT)
+
+    context_builder = ContextBuilder("relaxed precision")
+    add_timer_fired_events(context_builder, 0, relaxed_timestamp)
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function)
+
+    expected_state = base_expected_state(output='Done!')
+    add_timer_action(expected_state, fire_at)
+
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    #assert_valid_schema(result)
+    # TODO: getting the following error when validating the schema
+    # "Additional properties are not allowed ('fireAt', 'isCanceled' were unexpected)">
+    assert_orchestration_state_equals(expected, result)

--- a/tests/test_utils/ContextBuilder.py
+++ b/tests/test_utils/ContextBuilder.py
@@ -64,8 +64,10 @@ class ContextBuilder:
         event.TaskScheduledId = id_
         self.history_events.append(event)
 
-    def add_timer_created_event(self, id_: int):
+    def add_timer_created_event(self, id_: int, timestamp: str = None):
         fire_at = self.current_datetime.strftime(DATETIME_STRING_FORMAT)
+        if timestamp is not None:
+            fire_at = timestamp
         event = self.get_base_event(HistoryEventType.TIMER_CREATED, id_=id_)
         event.FireAt = fire_at
         self.history_events.append(event)


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/168

This PR improves our `datetime` comparison logic, which is crucial for finding durable-timer-creation events in the state array. Before, we compared `datetime` objects using their `toString` representation, but some `datetime` subtypes (timezone aware datetimes) have a slightly different string representations of dates. As a result, some equivalent dates failed to actually be acknowledged as equal.

The solution here takes two steps. First, instead of comparing strings, we compare proper `datetime` objects against each other. However, timezone-aware `datetime`s and timezone-naive `datetime`s are not directly comparable. As a result, I force all `datetime` objects to be timezone-naive, but I'm unsure how safe this is, and worry about this breaking in the cloud.

I'm not sure of why we have the two `datetime` variants floating in our codebase. It would be good to unify their representations. Are the dates flowing through durable-extension always in the same timezone? If so, I could force them all to be under that timezone, which strikes me as safer than removing the timezone metadata.

Happy to explain this further, if needed!