### PR TITLE
Type refactor for runtimeStatus

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -442,7 +442,7 @@ class DurableOrchestrationClient:
                         lambda: self._create_http_response(500, status.to_json()),
                 }
 
-                result = switch_statement.get(OrchestrationRuntimeStatus(status.runtime_status))
+                result = switch_statement.get(status.runtime_status)
                 if result:
                     return result()
 

--- a/azure/durable_functions/models/DurableOrchestrationStatus.py
+++ b/azure/durable_functions/models/DurableOrchestrationStatus.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from dateutil.parser import parse as dt_parse
 from typing import Any, List, Dict, Optional, Union
-
+from .OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 from .utils.json_utils import add_attrib, add_datetime_attrib
 
 
@@ -15,7 +15,8 @@ class DurableOrchestrationStatus:
     def __init__(self, name: Optional[str] = None, instanceId: Optional[str] = None,
                  createdTime: Optional[str] = None, lastUpdatedTime: Optional[str] = None,
                  input: Optional[Any] = None, output: Optional[Any] = None,
-                 runtimeStatus: Optional[str] = None, customStatus: Optional[Any] = None,
+                 runtimeStatus: Optional[OrchestrationRuntimeStatus] = None,
+                 customStatus: Optional[Any] = None,
                  history: Optional[List[Any]] = None,
                  **kwargs):
         self._name: Optional[str] = name
@@ -26,7 +27,9 @@ class DurableOrchestrationStatus:
             if lastUpdatedTime is not None else None
         self._input: Any = input
         self._output: Any = output
-        self._runtime_status: Optional[str] = runtimeStatus  # TODO: GH issue 178
+        self._runtime_status: Optional[OrchestrationRuntimeStatus] = runtimeStatus
+        if runtimeStatus is not None:
+            self._runtime_status = OrchestrationRuntimeStatus(runtimeStatus)
         self._custom_status: Any = customStatus
         self._history: Optional[List[Any]] = history
         if kwargs is not None:
@@ -82,7 +85,8 @@ class DurableOrchestrationStatus:
         add_datetime_attrib(json, self, 'last_updated_time', 'lastUpdatedTime')
         add_attrib(json, self, 'output')
         add_attrib(json, self, 'input_', 'input')
-        add_attrib(json, self, 'runtime_status', 'runtimeStatus')
+        if self.runtime_status is not None:
+            json["runtimeStatus"] = self.runtime_status.name
         add_attrib(json, self, 'custom_status', 'customStatus')
         add_attrib(json, self, 'history')
         return json
@@ -129,7 +133,7 @@ class DurableOrchestrationStatus:
         return self._output
 
     @property
-    def runtime_status(self) -> Optional[str]:
+    def runtime_status(self) -> Optional[OrchestrationRuntimeStatus]:
         """Get the runtime status of the orchestration instance."""
         return self._runtime_status
 

--- a/tests/models/test_DurableOrchestrationClient.py
+++ b/tests/models/test_DurableOrchestrationClient.py
@@ -147,7 +147,7 @@ async def test_get_202_get_status_success(binding_string):
 
     result = await client.get_status(TEST_INSTANCE_ID)
     assert result is not None
-    assert result.runtime_status == "Running"
+    assert result.runtime_status.name == "Running"
 
 
 @pytest.mark.asyncio
@@ -161,7 +161,7 @@ async def test_get_200_get_status_success(binding_string):
 
     result = await client.get_status(TEST_INSTANCE_ID)
     assert result is not None
-    assert result.runtime_status == "Completed"
+    assert result.runtime_status.name == "Completed"
 
 
 @pytest.mark.asyncio
@@ -465,8 +465,10 @@ async def test_wait_or_response_200_failed(binding_string):
     client = DurableOrchestrationClient(binding_string)
     client._get_async_request = mock_request.get
 
+    print("!!!")
     result = await client.wait_for_completion_or_create_check_status_response(
         None, TEST_INSTANCE_ID)
+    print("-----------------")
     assert result is not None
     assert result.status_code == 500
     assert result.mimetype == 'application/json'

--- a/tests/models/test_DurableOrchestrationClient.py
+++ b/tests/models/test_DurableOrchestrationClient.py
@@ -465,10 +465,8 @@ async def test_wait_or_response_200_failed(binding_string):
     client = DurableOrchestrationClient(binding_string)
     client._get_async_request = mock_request.get
 
-    print("!!!")
     result = await client.wait_for_completion_or_create_check_status_response(
         None, TEST_INSTANCE_ID)
-    print("-----------------")
     assert result is not None
     assert result.status_code == 500
     assert result.mimetype == 'application/json'

--- a/tests/models/test_DurableOrchestrationStatus.py
+++ b/tests/models/test_DurableOrchestrationStatus.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse as dt_parse
 
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
 from azure.durable_functions.models.DurableOrchestrationStatus import DurableOrchestrationStatus
+from azure.durable_functions.models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 from azure.durable_functions.models.history import HistoryEventType
 
 TEST_NAME = 'what ever I want it to be'
@@ -38,7 +39,7 @@ def test_all_the_args():
 
     result = DurableOrchestrationStatus.from_json(response)
 
-    assert result.runtime_status == TEST_RUNTIME_STATUS
+    assert result.runtime_status.name == TEST_RUNTIME_STATUS
     assert result.custom_status == TEST_CUSTOM_STATUS
     assert result.instance_id == TEST_INSTANCE_ID
     assert result.output == TEST_OUTPUT


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/178

Before, our runtimeStatus variable was allowed to hold any string value, or None. Now, we restrict its possible values by an Enum, giving us finer grained control of its values. Small PR