### PR TITLE
No JSON response format validation in PurgeHistory Ops

### DIFF
--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -65,5 +65,5 @@ async def delete_async_request(url: str) -> List[Union[int, Any]]:
     """
     async with aiohttp.ClientSession() as session:
         async with session.delete(url) as response:
-            data = await response.json()
+            data = await response.json(content_type=None)
             return [response.status, data]


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/183

We've consistently had issues with `aioHttp`, which tries to validate the format of durable-extension and function-host messages, resulting in exceptions. We got hit by the same issue yet again in ticket listed above. I believe this should be the last instance of this sneaky bug.