### PR TITLE
Added missing 'kind' field in TokenSource's serialized form

### DIFF
--- a/azure/durable_functions/models/TokenSource.py
+++ b/azure/durable_functions/models/TokenSource.py
@@ -32,6 +32,7 @@ class ManagedIdentityTokenSource(TokenSource):
     def __init__(self, resource: str):
         super().__init__()
         self._resource: str = resource
+        self._kind: str = "AzureManagedIdentity"
 
     @property
     def resource(self) -> str:
@@ -51,4 +52,5 @@ class ManagedIdentityTokenSource(TokenSource):
         """
         json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'resource')
+        json_dict["kind"] = self._kind
         return json_dict

--- a/tests/models/test_TokenSource.py
+++ b/tests/models/test_TokenSource.py
@@ -1,0 +1,11 @@
+from azure.durable_functions.models.TokenSource import ManagedIdentityTokenSource
+
+def test_serialization_fields():
+    """Validates the TokenSource contains the expected fields when serialized to JSON"""
+    token_source = ManagedIdentityTokenSource(resource="TOKEN_SOURCE")
+    token_source_json = token_source.to_json()
+
+    # JSON should contain a resource field and a kind field set to `AzureManagedIdentity`
+    assert "resource" in token_source_json.keys()
+    assert "kind" in token_source_json.keys()
+    assert token_source_json["kind"] == "AzureManagedIdentity"

--- a/tests/models/test_TokenSource.py
+++ b/tests/models/test_TokenSource.py
@@ -5,7 +5,7 @@ def test_serialization_fields():
     token_source = ManagedIdentityTokenSource(resource="TOKEN_SOURCE")
     token_source_json = token_source.to_json()
 
-    # JSON should contain a resource field and a kind field set to `AzureManagedIdentity`
+    # Output JSON should contain a resource field and a kind field set to `AzureManagedIdentity`
     assert "resource" in token_source_json.keys()
     assert "kind" in token_source_json.keys()
     assert token_source_json["kind"] == "AzureManagedIdentity"


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/208

In this short PR, we add a missing field to `TokenSource`'s JSON representation. This field is `kind` and it needs to be set to `AzureManagedIdentity`  for it to work currently.