### PR TITLE
Add Client Signal Entity 

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -459,10 +459,10 @@ class DurableOrchestrationClient:
                 return self.create_check_status_response(request, instance_id)
 
     async def signal_entity(self, entityId: EntityId, operation_name: str,
-                         operation_input: Optional[Any] = None,
-                         task_hub_name: Optional[str] = None,
-                         connection_name: Optional[str] = None) -> None:
-        """Signals an entity to perform an operation
+                            operation_input: Optional[Any] = None,
+                            task_hub_name: Optional[str] = None,
+                            connection_name: Optional[str] = None) -> None:
+        """Signals an entity to perform an operation.
 
         Parameters
         ----------
@@ -487,12 +487,14 @@ class DurableOrchestrationClient:
         None
         """
         options = RpcManagementOptions(operation_name=operation_name,
-                                        connection_name=connection_name,
-                                        task_hub_name=task_hub_name,
-                                        entity_Id=entityId)
+                                       connection_name=connection_name,
+                                       task_hub_name=task_hub_name,
+                                       entity_Id=entityId)
 
         request_url = options.to_url(self._orchestration_bindings.rpc_base_url)
-        response = await self._post_async_request(request_url, json.dumps(operation_input) if operation_input else None)
+        response = await self._post_async_request(
+            request_url,
+            json.dumps(operation_input) if operation_input else None)
 
         switch_statement = {
             202: lambda: None  # signal accepted
@@ -501,7 +503,7 @@ class DurableOrchestrationClient:
         has_error_message = switch_statement.get(
             response[0],
             lambda: f"The operation failed with an unexpected status code {response[0]}")
-        
+
         error_message = has_error_message()
 
         if error_message:

--- a/azure/durable_functions/models/RpcManagementOptions.py
+++ b/azure/durable_functions/models/RpcManagementOptions.py
@@ -6,6 +6,7 @@ from azure.durable_functions.models.OrchestrationRuntimeStatus import Orchestrat
 
 from .utils.entity_utils import EntityId
 
+
 class RpcManagementOptions:
     """Class used to collect the options for getting orchestration status."""
 
@@ -14,7 +15,7 @@ class RpcManagementOptions:
                  show_history_output: bool = None, created_time_from: datetime = None,
                  created_time_to: datetime = None,
                  runtime_status: List[OrchestrationRuntimeStatus] = None, show_input: bool = None,
-                 operation_name : str = None,
+                 operation_name: str = None,
                  entity_Id: EntityId = None):
         self._instance_id = instance_id
         self._task_hub_name = task_hub_name
@@ -38,7 +39,7 @@ class RpcManagementOptions:
         if value:
             date_as_string = value.strftime(DATETIME_STRING_FORMAT)
             RpcManagementOptions._add_arg(query, name, date_as_string)
-           
+
     def to_url(self, base_url: Optional[str]) -> str:
         """Get the url based on the options selected.
 

--- a/azure/durable_functions/models/RpcManagementOptions.py
+++ b/azure/durable_functions/models/RpcManagementOptions.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
 from azure.durable_functions.models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 
+from .utils.entity_utils import EntityId
 
 class RpcManagementOptions:
     """Class used to collect the options for getting orchestration status."""
@@ -12,7 +13,9 @@ class RpcManagementOptions:
                  connection_name: str = None, show_history: bool = None,
                  show_history_output: bool = None, created_time_from: datetime = None,
                  created_time_to: datetime = None,
-                 runtime_status: List[OrchestrationRuntimeStatus] = None, show_input: bool = None):
+                 runtime_status: List[OrchestrationRuntimeStatus] = None, show_input: bool = None,
+                 operation_name : str = None,
+                 entity_Id: EntityId = None):
         self._instance_id = instance_id
         self._task_hub_name = task_hub_name
         self._connection_name = connection_name
@@ -22,6 +25,8 @@ class RpcManagementOptions:
         self._created_time_to = created_time_to
         self._runtime_status = runtime_status
         self._show_input = show_input
+        self.operation_name = operation_name
+        self.entity_Id = entity_Id
 
     @staticmethod
     def _add_arg(query: List[str], name: str, value: Any):
@@ -33,7 +38,7 @@ class RpcManagementOptions:
         if value:
             date_as_string = value.strftime(DATETIME_STRING_FORMAT)
             RpcManagementOptions._add_arg(query, name, date_as_string)
-
+           
     def to_url(self, base_url: Optional[str]) -> str:
         """Get the url based on the options selected.
 
@@ -55,7 +60,10 @@ class RpcManagementOptions:
         if base_url is None:
             raise ValueError("orchestration bindings has not RPC base url")
 
-        url = f"{base_url}instances/{self._instance_id if self._instance_id else ''}"
+        if self.entity_Id:
+            url = f'{base_url}{EntityId.get_entity_id_url_path(self.entity_Id)}'
+        else:
+            url = f"{base_url}instances/{self._instance_id if self._instance_id else ''}"
 
         query: List[str] = []
 
@@ -66,6 +74,7 @@ class RpcManagementOptions:
         self._add_arg(query, 'showHistoryOutput', self._show_history_output)
         self._add_date_arg(query, 'createdTimeFrom', self._created_time_from)
         self._add_date_arg(query, 'createdTimeTo', self._created_time_to)
+        self._add_arg(query, 'op', self.operation_name)
         if self._runtime_status is not None and len(self._runtime_status) > 0:
             runtime_status = ",".join(r.value for r in self._runtime_status)
             self._add_arg(query, 'runtimeStatus', runtime_status)

--- a/azure/durable_functions/models/utils/entity_utils.py
+++ b/azure/durable_functions/models/utils/entity_utils.py
@@ -69,6 +69,19 @@ class EntityId:
         [name, key] = components
         return EntityId(name, key)
 
+    @staticmethod
+    def get_entity_id_url_path(entity_id: 'EntityId') -> str:
+
+        """Print the the entity url path.
+
+        Returns
+        -------
+        str:
+            A url path of the EntityId
+        """
+
+        return f'entities/{entity_id.name}/{entity_id.key}'
+
     def __str__(self) -> str:
         """Print the string representation of this EntityId.
 

--- a/azure/durable_functions/models/utils/entity_utils.py
+++ b/azure/durable_functions/models/utils/entity_utils.py
@@ -71,7 +71,6 @@ class EntityId:
 
     @staticmethod
     def get_entity_id_url_path(entity_id: 'EntityId') -> str:
-
         """Print the the entity url path.
 
         Returns
@@ -79,7 +78,6 @@ class EntityId:
         str:
             A url path of the EntityId
         """
-
         return f'entities/{entity_id.name}/{entity_id.key}'
 
     def __str__(self) -> str:


### PR DESCRIPTION
Add client signal entity support for python durable extension! Microsoft Docs for [other languages.](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities?tabs=javascript#example-client-signals-an-entity)

Sample Usage:

```python
    client = DurableOrchestrationClient(starter)
    entityId = df.EntityId("Counter", "myCounter")
    await client.signal_entity(entityId, "add", 1)
```
