### PR TITLE
Serialize input for CallActivityWithRetryAction

### DIFF
--- a/azure/durable_functions/models/actions/CallActivityWithRetryAction.py
+++ b/azure/durable_functions/models/actions/CallActivityWithRetryAction.py
@@ -1,9 +1,11 @@
+from json import dumps
 from typing import Dict, Union
 
 from .Action import Action
 from .ActionType import ActionType
 from ..RetryOptions import RetryOptions
 from ..utils.json_utils import add_attrib, add_json_attrib
+from azure.functions._durable_functions import _serialize_custom_object
 
 
 class CallActivityWithRetryAction(Action):
@@ -16,7 +18,7 @@ class CallActivityWithRetryAction(Action):
                  retry_options: RetryOptions, input_=None):
         self.function_name: str = function_name
         self.retry_options: RetryOptions = retry_options
-        self.input_ = input_
+        self.input_ = dumps(input_, default=_serialize_custom_object)
 
         if not self.function_name:
             raise ValueError("function_name cannot be empty")


### PR DESCRIPTION
See: https://github.com/Azure/azure-functions-durable-python/issues/224

**Changes**
- JSON serialize `CallActivityWithRetryAction.input_` (based on CallActivityAction.input_`)
- Added `test_retries_with_serializable_input` in test_retries.py
    - New tests fails without `CallActivityWithRetryAction` change, as expected
 