### PR TITLE
Remove typing in __init__.py

### DIFF
--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -1,4 +1,3 @@
 """Base module for the Python Durable functions."""
 from pkgutil import extend_path
-import typing
-__path__: typing.Iterable[str] = extend_path(__path__, __name__)
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
Resolves:  https://github.com/Azure/azure-functions-durable-python/issues/258
Simple routine PR to remove `__init__.py ` typings. Necessary for a better integration w/ azure docs