### PR TITLE
Export OrchestrationRuntimeStatus for getStatus comparisons

### DIFF
--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -6,10 +6,10 @@ from .orchestrator import Orchestrator
 from .entity import Entity
 from .models.utils.entity_utils import EntityId
 from .models.DurableOrchestrationClient import DurableOrchestrationClient
-from .models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus # noqa: 401
+from .models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 from .models.DurableOrchestrationContext import DurableOrchestrationContext
 from .models.DurableEntityContext import DurableEntityContext
-from .models.RetryOptions import RetryOptions # noqa: 401
+from .models.RetryOptions import RetryOptions
 from .models.TokenSource import ManagedIdentityTokenSource
 import json
 from pathlib import Path
@@ -64,6 +64,6 @@ __all__ = [
     'DurableEntityContext',
     'DurableOrchestrationContext',
     'ManagedIdentityTokenSource',
-    'OrchestrationRuntimeStatus'
+    'OrchestrationRuntimeStatus',
     'RetryOptions'
 ]

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -6,10 +6,10 @@ from .orchestrator import Orchestrator
 from .entity import Entity
 from .models.utils.entity_utils import EntityId
 from .models.DurableOrchestrationClient import DurableOrchestrationClient
-from .models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
+from .models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus # noqa: 401
 from .models.DurableOrchestrationContext import DurableOrchestrationContext
 from .models.DurableEntityContext import DurableEntityContext
-from .models.RetryOptions import RetryOptions
+from .models.RetryOptions import RetryOptions # noqa: 401
 from .models.TokenSource import ManagedIdentityTokenSource
 import json
 from pathlib import Path

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -6,6 +6,7 @@ from .orchestrator import Orchestrator
 from .entity import Entity
 from .models.utils.entity_utils import EntityId
 from .models.DurableOrchestrationClient import DurableOrchestrationClient
+from .models.OrchestrationRuntimeStatus import OrchestrationRuntimeStatus
 from .models.DurableOrchestrationContext import DurableOrchestrationContext
 from .models.DurableEntityContext import DurableEntityContext
 from .models.RetryOptions import RetryOptions
@@ -63,5 +64,6 @@ __all__ = [
     'DurableEntityContext',
     'DurableOrchestrationContext',
     'ManagedIdentityTokenSource',
+    'OrchestrationRuntimeStatus'
     'RetryOptions'
 ]

--- a/samples/counter_entity/DurableOrchestration/__init__.py
+++ b/samples/counter_entity/DurableOrchestration/__init__.py
@@ -27,7 +27,6 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
     state
         The state after applying the operation on the Durable Entity
     """
-    b = df.RetryOptions
     entityId = df.EntityId("Counter", "myCounter")
     context.signal_entity(entityId, "add", 3)
     state = yield context.call_entity(entityId, "get")

--- a/samples/counter_entity/DurableOrchestration/__init__.py
+++ b/samples/counter_entity/DurableOrchestration/__init__.py
@@ -27,6 +27,7 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
     state
         The state after applying the operation on the Durable Entity
     """
+    b = df.RetryOptions
     entityId = df.EntityId("Counter", "myCounter")
     context.signal_entity(entityId, "add", 3)
     state = yield context.call_entity(entityId, "get")


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-functions-durable-python/issues/195

This tiny PR exports the `OrchestrationRuntimeStatus` `enum` which allows for safer checks around an orchestration runtime state. This should have been done a long time ago as the `runtime_status` field of a  `DurableOrchestrationStatus` object was already of `OrchestrationRuntimeStatus` and yet customers didn't access to the `enum` declaration itself.

**Example:**
Checking the status of an orchestration used to be as follows:

```Python
# ...
existing_instance = await client.get_status(instance_id)
my_check existing_instance._runtime_status.name == "Pending"
# ...
```

Whereas now users can do, and are encourage to opt for, the following:

```Python
# ...
existing_instance = await client.get_status(instance_id)
my_check existing_instance._runtime_status is df.OrchestrationRuntimeStatus.Pending
# ...
```

I believe this enum-based comparison is already what happens in JavaScript.

**Still ToDo:**
* Update docs with an example or reference to this API: https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-instance-management?tabs=csharp#query-instances