### PR TITLE
Replace exception for warning when validating extension bundles range

### DIFF
--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -47,7 +47,9 @@ def validate_extension_bundles():
         # We do a best-effort attempt to detect bundles V1
         # This is the string hard-coded into the bundles V1 template in VSCode
         if version_range == "[1.*, 2.0.0)":
-            message = "Durable Functions for Python will stop supporting Bundles V1."\
+            message = "Your application is currently configured to use Extension Bundles V1."\
+                " Durable Functions for Python works best with Bundles V2, "\
+                " which provides additional features like Durable Entities, better performance, and is actively being developed."\
                 " Please update to Bundles V2 in your `host.json`."\
                 " You can set extensionBundles version to be: [2.*, 3.0.0)"
             warnings.warn(message)

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -48,7 +48,7 @@ def validate_extension_bundles():
         # This is the string hard-coded into the bundles V1 template in VSCode
         if version_range == "[1.*, 2.0.0)":
             message = "Your application is currently configured to use Extension Bundles V1."\
-                " Durable Functions for Python works best with Bundles V2, "\
+                " Durable Functions for Python works best with Bundles V2,"\
                 " which provides additional features like Durable Entities, better performance, and is actively being developed."\
                 " Please update to Bundles V2 in your `host.json`."\
                 " You can set extensionBundles version to be: [2.*, 3.0.0)"

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -49,7 +49,8 @@ def validate_extension_bundles():
         if version_range == "[1.*, 2.0.0)":
             message = "Your application is currently configured to use Extension Bundles V1."\
                 " Durable Functions for Python works best with Bundles V2,"\
-                " which provides additional features like Durable Entities, better performance, and is actively being developed."\
+                " which provides additional features like Durable Entities, better performance,"\
+                " and is actively being developed."\
                 " Please update to Bundles V2 in your `host.json`."\
                 " You can set extensionBundles version to be: [2.*, 3.0.0)"
             warnings.warn(message)

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -13,14 +13,15 @@ from .models.TokenSource import ManagedIdentityTokenSource
 import json
 from pathlib import Path
 import sys
+import warnings
 
 
 def validate_extension_bundles():
-    """Throw an exception if host.json contains bundle-range V1.
+    """Raise a warning if host.json contains bundle-range V1.
 
-    Raises
+    Effects
     ------
-        Exception: Exception prompting the user to update to bundles V2
+        Warning: Exception prompting the user to update to bundles V2
     """
     # No need to validate if we're running tests
     if "pytest" in sys.modules:
@@ -46,10 +47,10 @@ def validate_extension_bundles():
         # We do a best-effort attempt to detect bundles V1
         # This is the string hard-coded into the bundles V1 template in VSCode
         if version_range == "[1.*, 2.0.0)":
-            message = "Durable Functions for Python does not support Bundles V1."\
+            message = "Durable Functions for Python will stop supporting Bundles V1."\
                 " Please update to Bundles V2 in your `host.json`."\
                 " You can set extensionBundles version to be: [2.*, 3.0.0)"
-            raise Exception(message)
+            warnings.warn(message)
 
 
 # Validate that users are not in extension bundles V1

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -21,7 +21,7 @@ def validate_extension_bundles():
 
     Effects
     ------
-        Warning: Exception prompting the user to update to bundles V2
+        Warning: Warning prompting the user to update to bundles V2
     """
     # No need to validate if we're running tests
     if "pytest" in sys.modules:


### PR DESCRIPTION
Follow-up to: https://github.com/Azure/azure-functions-durable-python/pull/238

Previously, we were throwing an exception when a `host.json` was detected with a bundles  V1 range. Since we have decided to support bundles v1 until an official deprecation timeline is established, we'll instead throw a warning.

The warning looks as follows:
![warning](https://user-images.githubusercontent.com/9623336/108759570-6089e900-7501-11eb-9647-d812495193d2.PNG)
