### PR TITLE
Implement new_guid API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,6 @@ venv.bak/
 
 # Visual Studio
 .vs/
-.vscode/
 
 # CSharp
 [Oo]bj/
@@ -132,3 +131,5 @@ appsettings.*.json
 /samples/python_durable_bindings/bin/
 /samples/python_durable_bindings/.vs/
 /samples/python_durable_bindings/obj/
+
+.python_packages

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ venv.bak/
 
 # Visual Studio
 .vs/
+.vscode/
 
 # CSharp
 [Oo]bj/
@@ -131,5 +132,3 @@ appsettings.*.json
 /samples/python_durable_bindings/bin/
 /samples/python_durable_bindings/.vs/
 /samples/python_durable_bindings/obj/
-
-.python_packages

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 from typing import List, Any, Dict, Optional
+from uuid import UUID, uuid5, NAMESPACE_URL
 
 from .RetryOptions import RetryOptions
 from .TaskSet import TaskSet
@@ -444,3 +445,17 @@ class DurableOrchestrationContext:
             The new starting input to the orchestrator.
         """
         return continue_as_new(context=self, input_=input_)
+
+    def new_guid(self) -> UUID:
+        """Generate a replay-safe GUID.
+
+        Returns
+        -------
+        UUID
+            A new globally-unique ID
+        """
+        guid_name = f"{self.instance_id}_{self.current_utc_datetime}"\
+            f"_{self._new_uuid_counter}"
+        self._new_uuid_counter += 1
+        guid = uuid5(NAMESPACE_URL, guid_name)
+        return guid

--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -91,6 +91,19 @@ def generator_function_with_serialization(context):
 
     return outputs
 
+def generator_function_new_guid(context):
+    """Simple orchestrator that generates 3 GUIDs"""
+    outputs = []
+
+    output1 = context.new_guid()
+    output2 = context.new_guid()
+    output3 = context.new_guid()
+
+    outputs.append(str(output1))
+    outputs.append(str(output2))
+    outputs.append(str(output3))
+    return outputs
+
 
 def base_expected_state(output=None) -> OrchestratorState:
     return OrchestratorState(is_done=False, actions=[], output=output)
@@ -352,4 +365,23 @@ def test_utc_time_updates_correctly():
 
     assert_valid_schema(result)
     assert_orchestration_state_equals(expected, result)
+
+def test_new_guid_orchestrator():
+    """Tests that the new_guid API is replay-safe and produces new GUIDs every time"""
+    context_builder = ContextBuilder('test_guid_orchestrator')
+
+    # To test that the API is replay-safe, we generate two orchestrators
+    # with the same starting context
+    result1 = get_orchestration_state_result(
+        context_builder, generator_function_new_guid)
+    outputs1 = result1["output"]
+
+    result2 = get_orchestration_state_result(
+        context_builder, generator_function_new_guid)
+    outputs2 = result2["output"]
+
+    # All GUIDs should be unique
+    assert len(outputs1) == len(set(outputs1))
+    # The two GUID lists should be the same
+    assert outputs1 == outputs2
 


### PR DESCRIPTION
Addresses part of: https://github.com/Azure/azure-functions-durable-python/issues/261

It was recently brought to our attention that the `newGUID` API was not documented in the Durable Docs for Python. This is because this API had not been implemented, until now. This PR implements this API via `new_guid`.

For reference, the corresponding implementation for JS is here: https://github.com/Azure/azure-functions-durable-js/blob/297cc490e70b06eb7ebe418edefb4f5aa2b7fee1/src/guidmanager.ts#L17

Note that the `uuid` API in Python is much more high-level than is JS, so we do not need to create the `sha1` hash ourselves, it's all nicely wrapped in one call to the python standard library 🐍 