### PR TITLE
Add debugging helper to pretty print history

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -1,7 +1,9 @@
 import json
 import datetime
+import inspect
 from typing import List, Any, Dict, Optional
 from uuid import UUID, uuid5, NAMESPACE_URL
+from datetime import timezone
 
 from .RetryOptions import RetryOptions
 from .TaskSet import TaskSet
@@ -459,3 +461,14 @@ class DurableOrchestrationContext:
         self._new_uuid_counter += 1
         guid = uuid5(NAMESPACE_URL, guid_name)
         return guid
+    
+    def _pretty_print_history(self) -> str:
+        def history_to_string(event):
+            json_dict = {}
+            for key, val in inspect.getmembers(event):
+                if not key.startswith('_') and not inspect.ismethod(val):
+                    if isinstance(val, datetime.date):
+                        val = val.replace(tzinfo=timezone.utc).timetuple()
+                    json_dict[key] = val
+            return json.dumps(json_dict)
+        return list(map(history_to_string, self._histories))

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -461,8 +461,9 @@ class DurableOrchestrationContext:
         self._new_uuid_counter += 1
         guid = uuid5(NAMESPACE_URL, guid_name)
         return guid
-    
+
     def _pretty_print_history(self) -> str:
+        """Get a pretty-printed version of the orchestration's internal history."""
         def history_to_string(event):
             json_dict = {}
             for key, val in inspect.getmembers(event):

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -462,7 +462,7 @@ class DurableOrchestrationContext:
         guid = uuid5(NAMESPACE_URL, guid_name)
         return guid
 
-    def _pretty_print_history(self) -> str:
+    def _pretty_print_history(self) -> List[str]:
         """Get a pretty-printed version of the orchestration's internal history."""
         def history_to_string(event):
             json_dict = {}

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -462,7 +462,7 @@ class DurableOrchestrationContext:
         guid = uuid5(NAMESPACE_URL, guid_name)
         return guid
 
-    def _pretty_print_history(self) -> List[str]:
+    def _pretty_print_history(self) -> str:
         """Get a pretty-printed version of the orchestration's internal history."""
         def history_to_string(event):
             json_dict = {}
@@ -472,4 +472,4 @@ class DurableOrchestrationContext:
                         val = val.replace(tzinfo=timezone.utc).timetuple()
                     json_dict[key] = val
             return json.dumps(json_dict)
-        return list(map(history_to_string, self._histories))
+        return str(list(map(history_to_string, self._histories)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==5.3.2
 python-dateutil==2.8.0
 requests==2.22.0
 jsonschema==3.2.0
-aiohttp==3.6.2
+aiohttp==3.7.4
 azure-functions>=1.2.0
 nox==2019.11.9
 furl==2.1.0


### PR DESCRIPTION
Inspired by: https://github.com/Azure/azure-functions-durable-python/issues/280

Certain bugs, especially those with strange logging behavior in production, are easier to diagnose if the end-user can provide us with a snapshot of their orchestration's internal history during replay.

This PR exposes an easy-to-access utility to help end-users pretty-print their orchestration history to do just that. I prefix the method name with an underscore, following python conventions, to flag it as an internal or debug-only utility.