### PR TITLE
Avoid duplicate task yields

### DIFF
--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -26,6 +26,7 @@ class Task:
         self._id = id_
         self._exception = exc
         self._is_played = is_played
+        self._is_yielded: bool = False
 
     @property
     def is_completed(self) -> bool:

--- a/azure/durable_functions/models/TaskSet.py
+++ b/azure/durable_functions/models/TaskSet.py
@@ -25,6 +25,7 @@ class TaskSet:
         self._timestamp: datetime = timestamp
         self._exception = exception
         self._is_played = is_played
+        self._is_yielded: bool = False
 
     @property
     def is_completed(self) -> bool:

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -134,12 +134,14 @@ class Orchestrator:
         # Do not add new tasks to action if continue_as_new was called
         if self.durable_context.will_continue_as_new:
             return
-        if (isinstance(generation_state, Task)
-                and hasattr(generation_state, "action")):
-            self.durable_context.actions.append([generation_state.action])
-        elif (isinstance(generation_state, TaskSet)
-              and hasattr(generation_state, "actions")):
-            self.durable_context.actions.append(generation_state.actions)
+        if not generation_state._is_yielded:
+            if (isinstance(generation_state, Task)
+                    and hasattr(generation_state, "action")):
+                self.durable_context.actions.append([generation_state.action])
+            elif (isinstance(generation_state, TaskSet)
+                and hasattr(generation_state, "actions")):
+                self.durable_context.actions.append(generation_state.actions)
+            generation_state._is_yielded = True
 
     def _update_timestamp(self):
         last_timestamp = self.durable_context.decision_started_event.timestamp

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -139,7 +139,7 @@ class Orchestrator:
                     and hasattr(generation_state, "action")):
                 self.durable_context.actions.append([generation_state.action])
             elif (isinstance(generation_state, TaskSet)
-                and hasattr(generation_state, "actions")):
+                    and hasattr(generation_state, "actions")):
                 self.durable_context.actions.append(generation_state.actions)
             generation_state._is_yielded = True
 


### PR DESCRIPTION
This PR ensures that `yield`'ing a Task twice does not schedule the task again. Somehow, we were missing this check.