### PR TITLE
Change host.json in entity sample to use bundles

### DIFF
--- a/samples/counter_entity/host.json
+++ b/samples/counter_entity/host.json
@@ -1,3 +1,15 @@
 {
-  "version": "2.0"
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[2.*, 3.0.0)"
+  }
 }

--- a/samples/counter_entity/requirements.txt
+++ b/samples/counter_entity/requirements.txt
@@ -1,2 +1,2 @@
 azure-functions
-#azure-functions-durable>=1.0.0b6
+azure-functions-durable


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/294
The previous `host.json` in the entity sample contained no information about extension bundles. This meant, I believe, that the default (V1) extension bundles would be chosen when a user tried running the sample out of the box.

This PR rewrites that `host.json` to include an extensionBundles range, to make sure the expected version is selected.

