### PR TITLE
Increase sequence number in fire-and-forget APIs and fix ContinueAsNew Serialization

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -473,6 +473,7 @@ class DurableOrchestrationContext:
         else:
             new_action = [action]
         self._add_to_actions(new_action)
+        self._sequence_number += 1
 
     def signal_entity(self, entityId: EntityId,
                       operationName: str, operationInput: Optional[Any] = None):

--- a/azure/durable_functions/models/actions/ContinueAsNewAction.py
+++ b/azure/durable_functions/models/actions/ContinueAsNewAction.py
@@ -3,6 +3,8 @@ from typing import Dict, Union
 from .Action import Action
 from .ActionType import ActionType
 from ..utils.json_utils import add_attrib
+from json import dumps
+from azure.functions._durable_functions import _serialize_custom_object
 
 
 class ContinueAsNewAction(Action):
@@ -13,7 +15,7 @@ class ContinueAsNewAction(Action):
     """
 
     def __init__(self, input_=None):
-        self.input_ = input_
+        self.input_ = dumps(input_, default=_serialize_custom_object)
 
     @property
     def action_type(self) -> int:

--- a/tests/orchestrator/test_entity.py
+++ b/tests/orchestrator/test_entity.py
@@ -199,15 +199,16 @@ def test_signal_entity_sent():
 def test_signal_entity_sent_and_response_received():
     entityId = df.EntityId("Counter", "myCounter")
     context_builder = ContextBuilder('test_simple_function')
-    add_call_entity_completed_events(context_builder, "add", df.EntityId.get_scheduler_id(entityId), 3, 0)
+    add_call_entity_completed_events(context_builder, "get", df.EntityId.get_scheduler_id(entityId), 3, 1)
 
 
     result = get_orchestration_state_result(
         context_builder, generator_function_signal_entity)
 
-    expected_state = base_expected_state()
+    expected_state = base_expected_state([3])
     add_signal_entity_action(expected_state, entityId, "add", 3)
     add_call_entity_action(expected_state, entityId, "get", None)
+    expected_state._is_done = True
     expected = expected_state.to_json()
 
     #assert_valid_schema(result)

--- a/tests/orchestrator/test_entity.py
+++ b/tests/orchestrator/test_entity.py
@@ -196,6 +196,23 @@ def test_signal_entity_sent():
     #assert_valid_schema(result)
     assert_orchestration_state_equals(expected, result)
 
+def test_signal_entity_sent_and_response_received():
+    entityId = df.EntityId("Counter", "myCounter")
+    context_builder = ContextBuilder('test_simple_function')
+    add_call_entity_completed_events(context_builder, "add", df.EntityId.get_scheduler_id(entityId), 3, 0)
+
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function_signal_entity)
+
+    expected_state = base_expected_state()
+    add_signal_entity_action(expected_state, entityId, "add", 3)
+    add_call_entity_action(expected_state, entityId, "get", None)
+    expected = expected_state.to_json()
+
+    #assert_valid_schema(result)
+    assert_orchestration_state_equals(expected, result)
+
 
 def test_call_entity_raised():
     entityId = df.EntityId("Counter", "myCounter")


### PR DESCRIPTION
Follow-up to: #302

In the case of signalEntity, we need to increase the internal sequenceID for the following APIs to be correctly processing in our linear-pass algorithm. This PR adds that change.


_Additionally,_ I realized that in the pre-existing SDK, continueAsNew input strings weren't getting correctly serialized (they also need to be stringified) so this PR fixes that.