### PR TITLE
Handle empty-list in compound tasks

### DIFF
--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -159,6 +159,10 @@ class CompoundTask(TaskBase):
         self.completed_tasks: List[TaskBase] = []
         self.children = tasks
 
+        if len(self.children) == 0:
+            self.state =  TaskState.SUCCEEDED
+
+
     def handle_completion(self, child: TaskBase):
         """Manage sub-task completion events.
 

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -160,8 +160,7 @@ class CompoundTask(TaskBase):
         self.children = tasks
 
         if len(self.children) == 0:
-            self.state =  TaskState.SUCCEEDED
-
+            self.state = TaskState.SUCCEEDED
 
     def handle_completion(self, child: TaskBase):
         """Manage sub-task completion events.

--- a/tests/orchestrator/test_task_any.py
+++ b/tests/orchestrator/test_task_any.py
@@ -14,6 +14,19 @@ def generator_function(context):
     except:
         return "exception"
 
+def generator_function_no_activity(context):
+    yield context.task_any([])
+    return "Done!"
+
+def test_continues_on_zero_inner_tasks():
+    context_builder = ContextBuilder()
+    result = get_orchestration_state_result(
+        context_builder, generator_function_no_activity)
+    expected_state = base_expected_state("Done!")
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+    assert_orchestration_state_equals(expected, result)
+
 def test_continues_on_zero_results():
     context_builder = ContextBuilder()
     result = get_orchestration_state_result(


### PR DESCRIPTION
Addresses: https://github.com/Azure/azure-functions-durable-python/issues/315

This PR ensures that a compound task is not _stuck_ in a `Running` state after receiving an empty list of tasks.

This allows the following snippet to make progress:

```Python
yield context.task_all([]) # would previously get stuck
```