### PR TITLE
Update readme with a query to track upcoming features/fixes in the extension to extension bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Follow these instructions to get started with Durable Functions in Python:
 ## Tooling
 
 * Python Durable Functions requires [Azure Functions Core Tools](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) version 3.0.2630 or higher.
+
+## Features and fixes coming soon to Extension Bundles
+
+By default, Durable Functions for Python apps are set up to use [Extension Bundles](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles) to automatically manage binding extension dependencies; such as the [Durable Functions Extension](https://github.com/Azure/azure-functions-durable-extension). However, there can be a delay between the release of a new version of the Durable Functions Extension and its inclusion in the Extension Bundles feed.
+
+[This query](https://github.com/Azure/azure-functions-durable-extension/issues?q=label%3A%22not+in+bundles+yet%22) provides a list of known upcoming features and bug fixes that are still _on their way_ to being included in Extension bundles.
+
+If you need immediate access to an upcoming change in the Durable Functions Extension, please follow [these](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#explicitly-install-extensions) instructions to install the latest version of Durable Functions Nuget package [here](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask).


### PR DESCRIPTION
Motivated by this comment: https://github.com/Azure/azure-functions-durable-python/issues/280#issuecomment-908347506

I want to provide a note in our README about the potential delay between merging a fix in the Durable Extension and its release on Extension Bundles. The note includes a link to a query in the durable extension repo that should list all PRs and issues that are relevant to OOProc PLs but have not made it to Extension Bundles yet. The query does this by looking for all items with the label "not in bundles yet"

If we are to merge this then, as part of our release workflow for the Extension, we should include a step to determine if any old issues are already in extension bundles and, if so, remove their label.

If merged, I'll add this to the JS repo as well. I might also update our `issues` template with a note to this.
