### PR TITLE
Allow orchestrators to try-catch entity timeouts

### DIFF
--- a/azure/durable_functions/models/entities/ResponseMessage.py
+++ b/azure/durable_functions/models/entities/ResponseMessage.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+import json
 
 
 class ResponseMessage:
@@ -17,6 +18,13 @@ class ResponseMessage:
         result: str
             The result provided by the entity
         """
+        # The time-out case seems to be handled by the Functions-Host, so
+        # its result is not doubly-serialized. In this branch, we compensate
+        # for this by re-serializing the payload.
+        if result.strip().startswith("Timeout value of"):
+            is_exception = True
+            result = json.dumps(result)
+
         self.result = result
         self.is_exception = is_exception
         # TODO: JS has an additional exceptionType field, but does not use it

--- a/tests/orchestrator/test_entity.py
+++ b/tests/orchestrator/test_entity.py
@@ -192,11 +192,11 @@ def add_signal_entity_action(state: OrchestratorState, id_: df.EntityId, op: str
     state.actions.append([action])
 
 def add_call_entity_completed_events(
-        context_builder: ContextBuilder, op: str, instance_id=str, input_=None, event_id=0, is_error=False):
+        context_builder: ContextBuilder, op: str, instance_id=str, input_=None, event_id=0, is_error=False, literal_input=False):
     context_builder.add_event_sent_event(instance_id, event_id)
     context_builder.add_orchestrator_completed_event()
     context_builder.add_orchestrator_started_event()
-    context_builder.add_event_raised_event(name="0000", id_=0, input_=input_, is_entity=True, is_error=is_error)
+    context_builder.add_event_raised_event(name="0000", id_=0, input_=input_, is_entity=True, is_error=is_error, literal_input=literal_input)
 
 def test_call_entity_sent():
     context_builder = ContextBuilder('test_simple_function')
@@ -276,6 +276,32 @@ def test_call_entity_catch_exception():
         input_="I am an error!",
         event_id=0,
         is_error=True
+    )
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function_catch_entity_exception)
+
+    expected_state = base_expected_state(
+        "Exception thrown"
+    )
+
+    add_call_entity_action(expected_state, entityId, "add", 3)
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    assert_orchestration_state_equals(expected, result)
+
+def test_timeout_entity_catch_exception():
+    entityId = df.EntityId("Counter", "myCounter")
+    context_builder = ContextBuilder('catch timeout exceptions')
+    add_call_entity_completed_events(
+        context_builder,
+        "add",
+        df.EntityId.get_scheduler_id(entityId),
+        input_="Timeout value of ...",
+        event_id=0,
+        is_error=False,
+        literal_input=True
     )
 
     result = get_orchestration_state_result(

--- a/tests/orchestrator/test_entity.py
+++ b/tests/orchestrator/test_entity.py
@@ -298,7 +298,7 @@ def test_timeout_entity_catch_exception():
         context_builder,
         "add",
         df.EntityId.get_scheduler_id(entityId),
-        input_="Timeout value of ...",
+        input_="Timeout value of 00:02:00 was exceeded by function: Functions.SlowEntity.",
         event_id=0,
         is_error=False,
         literal_input=True

--- a/tests/test_utils/ContextBuilder.py
+++ b/tests/test_utils/ContextBuilder.py
@@ -125,14 +125,17 @@ class ContextBuilder:
         event.Input = input_
         self.history_events.append(event)
 
-    def add_event_raised_event(self, name:str, id_: int, input_=None, timestamp=None, is_entity=False, is_error = False):
+    def add_event_raised_event(self, name:str, id_: int, input_=None, timestamp=None, is_entity=False, is_error = False, literal_input=False):
         event = self.get_base_event(HistoryEventType.EVENT_RAISED, id_=id_, timestamp=timestamp)
         event.Name = name
         if is_entity:
             if is_error:
                 event.Input = json.dumps({ "result": json.dumps(input_), "exceptionType": "True" })
             else:
-                event.Input = json.dumps({ "result": json.dumps(input_) })
+                if literal_input:
+                    event.Input = json.dumps({ "result": input_ })
+                else:
+                    event.Input = json.dumps({ "result": json.dumps(input_) })
         else:
             event.Input = input_
         # event.timestamp = timestamp


### PR DESCRIPTION
This PR allows entity timeouts to be try-catched within orchestrators.

**EDIT:**

When an entity operation runs for too long, it runs the risk of being cancelled by the Functions Host due to it "timing out", that is, exceeding the maximum allowed execution time for a Function invocation. When this occurs, we consider the entity to have thrown an exception ( a timeout exception) and, as such, we expect to be able to try-catch it in the orchestrator. Currently, this doesn't happen.

To enable this scenario, there are changes required in the extension and in the SDK. Sebastian has been working on the extension changes in this [branch](https://github.com/Azure/azure-functions-durable-extension/tree/pr/entity-timeouts/test/TimeoutTests/Python) and, using that branch's changes, this PR implements the SDK-level changes that are leftover. 

In particular, during a time-out,  the HistoryEvent corresponding to this exception doesn't follow the serialization rules that normally govern Entity execution and therefore they require an extra step (to serialize the exception one more time) before they can be parsed by the SDK. This PR does just that.