### PR TITLE
Make `-WithRetry` APIs wait for TimerFired after final task failure

### DIFF
--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -374,7 +374,10 @@ class RetryAbleTask(WhenAllTask):
         if self.is_waiting_on_timer:
             # timer fired, re-scheduling original task
             self.is_waiting_on_timer = False
-
+            # As per DTFx semantics: we need to check the number of retires only after the final
+            # timer has fired. This means we essentially have to wait for one "extra" timer after
+            # the maximum number of attempts has been reached. Removing this extra timer will cause
+            # stuck orchestrators as we need to be "in sync" with the replay logic of DTFx.
             if self.num_attempts >= self.retry_options.max_number_of_attempts:
                 self.is_waiting_on_timer = True
                 # we have reached the maximum number of attempts, set error

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -403,4 +403,3 @@ class RetryAbleTask(WhenAllTask):
             self.context._add_to_open_tasks(timer_task)
             self.is_waiting_on_timer = True
             self.error = child.result
-    

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -403,3 +403,4 @@ class RetryAbleTask(WhenAllTask):
             self.context._add_to_open_tasks(timer_task)
             self.is_waiting_on_timer = True
             self.error = child.result
+    

--- a/tests/orchestrator/test_sequential_orchestrator_with_retry.py
+++ b/tests/orchestrator/test_sequential_orchestrator_with_retry.py
@@ -330,6 +330,7 @@ def test_failed_tokyo_hit_max_attempts_in_try_catch():
     add_hello_failed_events(context_builder, 2, failed_reason, failed_details)
     add_retry_timer_events(context_builder, 3)
     add_hello_failed_events(context_builder, 4, failed_reason, failed_details)
+    # we have an "extra" timer to wait for, due to legacy behavior in DTFx.
     add_retry_timer_events(context_builder, 5)
 
     # events to task in except block

--- a/tests/orchestrator/test_sequential_orchestrator_with_retry.py
+++ b/tests/orchestrator/test_sequential_orchestrator_with_retry.py
@@ -29,6 +29,19 @@ def generator_function(context):
 
     return outputs
 
+def generator_function_try_catch(context):
+    outputs = []
+
+    retry_options = RETRY_OPTIONS
+    result = None
+    try:
+        result = yield context.call_activity_with_retry(
+        "Hello", retry_options, "Tokyo")
+    except:
+        result = yield context.call_activity_with_retry(
+        "Hello",  retry_options, "Seattle")
+    return result
+
 def generator_function_concurrent_retries(context):
     outputs = []
 
@@ -304,6 +317,36 @@ def test_failed_tokyo_hit_max_attempts():
         
         expected_error_str = f"{error_msg}{error_label}{state_str}"
         assert expected_error_str == error_str
+
+def test_failed_tokyo_hit_max_attempts_in_try_catch():
+    # This test ensures that APIs can still be invoked after a failed CallActivityWithRetry invocation
+    failed_reason = 'Reasons'
+    failed_details = 'Stuff and Things'
+    context_builder = ContextBuilder('test_simple_function')
+    
+    # events for first task: "Hello Tokyo"
+    add_hello_failed_events(context_builder, 0, failed_reason, failed_details)
+    add_retry_timer_events(context_builder, 1)
+    add_hello_failed_events(context_builder, 2, failed_reason, failed_details)
+    add_retry_timer_events(context_builder, 3)
+    add_hello_failed_events(context_builder, 4, failed_reason, failed_details)
+    add_retry_timer_events(context_builder, 5)
+
+    # events to task in except block
+    add_hello_completed_events(context_builder, 6, "\"Hello Seattle!\"")
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function_try_catch)
+
+    expected_state = base_expected_state()
+    add_hello_action(expected_state, 'Tokyo')
+    add_hello_action(expected_state, 'Seattle')
+    expected_state._output = "Hello Seattle!"
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    assert_valid_schema(result)
+    assert_orchestration_state_equals(expected, result)
 
 def test_concurrent_retriable_results():
     failed_reason = 'Reasons'


### PR DESCRIPTION
This PR fixes the `-WithRetry` Task state machine implementation.

**Context:**

When invoking a `-WithRetry` API, users specify the maximum number of retries for that API.  

The current implementation assumes that, after receiving max-number-of-retries failure events for the task, no more History events associated with this API will be scheduled. However, DTFx schedules one final timer task after the final failure, and that task isn't currently being accounted for.

This, in turn, causes the History generated by DTFx to de-sync from the History expected by the SDK, leading to stuck orchestrations.

This PR patches the task state machine to account for this final timer task and adds a test to check for this scenario.