### PR TITLE
Use 1ES-hosted VM during build and release

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -11,7 +11,8 @@ resources:
 jobs:
     - job: Release
       pool:
-          vmImage: "ubuntu-latest"
+        name: "1ES-Hosted-AzFunc"
+        vmImage: "MMSUbuntu20.04TLS"
       steps:
           - task: UsePythonVersion@0
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ trigger:
     - v*
 
 variables:     
-  agentPool: 'ubuntu-latest' # 'Ubuntu-16.04'
   python.version: '3.6'
   baseFolder: .
   componentArtifactName: 'azure_functions_durable'
@@ -28,7 +27,8 @@ stages:
   - job: Build_Durable_Functions
     displayName: Build Python Package
     pool: 
-      vmImage: $(agentPool)
+      name: "1ES-Hosted-AzFunc"
+      vmImage: "MMSUbuntu20.04TLS"
     steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
Modeled after: https://github.com/Azure/azure-functions-durable-js/pull/303

This PR changes our vmImage when publishing and releasing durable-Python artifacts to use a 1ES hosted Ubuntu VM