### PR TITLE
"Demand" 1ES VM in pipelines 

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -12,7 +12,8 @@ jobs:
     - job: Release
       pool:
         name: "1ES-Hosted-AzFunc"
-        vmImage: "MMSUbuntu20.04TLS"
+        demands:
+            - ImageOverride -equals MMSUbuntu20.04TLS
       steps:
           - task: UsePythonVersion@0
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,8 @@ stages:
     displayName: Build Python Package
     pool: 
       name: "1ES-Hosted-AzFunc"
-      vmImage: "MMSUbuntu20.04TLS"
+      demands:
+          - ImageOverride -equals MMSUbuntu20.04TLS
     steps:
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
Modeled after: Azure/azure-functions-kafka-extension@8143947

This PR looks to ensure that our Azure pipelines use the 1ES VMs when building artifacts.