### PR TITLE
Add SBOM to release payload 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include _manifest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include _manifest
+include ./_manifest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include ./_manifest
+include ./_manifest/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,16 +56,10 @@ stages:
           BuildComponentPath: '$(baseFolder)'
           BuildDropPath: $(baseFolder)
           Verbosity: "Information"
-    - script: ls
-      workingDirectory: $(baseFolder) 
-      displayName: 'ls 1'
     - script: |
         python setup.py sdist bdist_wheel
       workingDirectory: $(baseFolder) 
       displayName: 'Building'
-    - script: ls
-      workingDirectory: $(baseFolder) 
-      displayName: 'ls 2'
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,10 +56,16 @@ stages:
           BuildComponentPath: '$(baseFolder)'
           BuildDropPath: $(baseFolder)
           Verbosity: "Information"
+    - script: ls
+      workingDirectory: $(baseFolder) 
+      displayName: 'ls 1'
     - script: |
         python setup.py sdist bdist_wheel
       workingDirectory: $(baseFolder) 
       displayName: 'Building'
+    - script: ls
+      workingDirectory: $(baseFolder) 
+      displayName: 'ls 2'
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,17 +50,16 @@ stages:
         pip install pytest pytest-azurepipelines
         pytest
       displayName: 'pytest'
-
-    - script: |
-        python setup.py sdist bdist_wheel
-      workingDirectory: $(baseFolder) 
-      displayName: 'Building'
     - task: ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"
       inputs:
           BuildComponentPath: '$(baseFolder)'
-          BuildDropPath: dist
+          BuildDropPath: $(baseFolder)
           Verbosity: "Information"
+    - script: |
+        python setup.py sdist bdist_wheel
+      workingDirectory: $(baseFolder) 
+      displayName: 'Building'
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: dist'
       inputs:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'pytest-asyncio==0.10.0'
     ],
     include_package_data=True,
-    package_data={'_manifest': ['*']}
+    package_data={'_manifest': ['*']},
     cmdclass={
         'build': BuildModule
     },

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     ],
     include_package_data=True,
     data_files= [
-        ('_manifest',glob('_manifest/**/*', recursive=True)),
+        ('_manifest',glob('_manifest/**/*.*', recursive=True)),
     ],
     cmdclass={
         'build': BuildModule

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     ],
     include_package_data=True,
     data_files= [
-        ('_manifest',glob('_manifest/**/*.*', recursive=True)),
+        ('_manifest', filter(os.path.isfile, glob('_manifest/**/*.*', recursive=True))),
     ],
     cmdclass={
         'build': BuildModule

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import subprocess
 import sys
-import glob
 
+from glob import glob
 from setuptools import setup, find_packages
 from distutils.command import build
 
@@ -65,6 +65,9 @@ setup(
         'pytest-asyncio==0.10.0'
     ],
     include_package_data=True,
+    data_files= [
+        ('_manifest',glob('_manifest/**/*', recursive=True)),
+    ],
     cmdclass={
         'build': BuildModule
     },

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     ],
     include_package_data=True,
     data_files= [
-        ('_manifest', filter(os.path.isfile, glob('_manifest/**/*.*', recursive=True))),
+        ('_manifest', list(filter(os.path.isfile, glob('_manifest/**/*', recursive=True)))),
     ],
     cmdclass={
         'build': BuildModule

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         'pytest-asyncio==0.10.0'
     ],
     include_package_data=True,
-    package_data={'_manifest': ['*']},
     cmdclass={
         'build': BuildModule
     },

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'pytest-asyncio==0.10.0'
     ],
     include_package_data=True,
+    package_data={'_manifest': ['*']}
     cmdclass={
         'build': BuildModule
     },


### PR DESCRIPTION
This PR adds the SBOM payload, inside the `_manifest` folder, to our `PyPI` package.

The manifest file can be found in different places depending on whether the user downloads an `sdist` distribution, or a `whl` distribution.

Inside the `sdist`, they'll find the manifest in a directory of the same name at the root of the code. See below.

![pypi_sdist](https://user-images.githubusercontent.com/9623336/154171130-6e001b22-a9ef-4a18-a7a4-d2a9ae8f532e.PNG)

Inside the `whl`, they'll find the manifest inside the `data > _manifest` sequence of directories, as evidenced below:

![pypi_wheel](https://user-images.githubusercontent.com/9623336/154171167-5e62a0bd-1ae6-4a4f-b419-8894028ff2c0.PNG)

