### PR TITLE
Serialize "innerTasks" only at the end of the orchestrator invocation

### DIFF
--- a/azure/durable_functions/models/actions/CompoundAction.py
+++ b/azure/durable_functions/models/actions/CompoundAction.py
@@ -13,8 +13,7 @@ class CompoundAction(Action):
     """
 
     def __init__(self, compoundTasks: List[Action]):
-        self.compound_actions = list(map(lambda x: x.to_json(), compoundTasks))
-
+        self.compoundTasks = compoundTasks
     @property
     @abstractmethod
     def action_type(self) -> int:
@@ -31,5 +30,5 @@ class CompoundAction(Action):
         """
         json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
-        add_attrib(json_dict, self, 'compound_actions', 'compoundActions')
+        json_dict['compoundActions'] = list(map(lambda x: x.to_json(), self.compoundTasks))
         return json_dict

--- a/azure/durable_functions/models/actions/CompoundAction.py
+++ b/azure/durable_functions/models/actions/CompoundAction.py
@@ -12,8 +12,8 @@ class CompoundAction(Action):
     Provides the information needed by the durable extension to be able to invoke WhenAll tasks.
     """
 
-    def __init__(self, compoundTasks: List[Action]):
-        self.compoundTasks = compoundTasks
+    def __init__(self, compound_tasks: List[Action]):
+        self.compound_tasks = compound_tasks
 
     @property
     @abstractmethod
@@ -31,5 +31,5 @@ class CompoundAction(Action):
         """
         json_dict: Dict[str, Union[str, int]] = {}
         add_attrib(json_dict, self, 'action_type', 'actionType')
-        json_dict['compoundActions'] = list(map(lambda x: x.to_json(), self.compoundTasks))
+        json_dict['compoundActions'] = list(map(lambda x: x.to_json(), self.compound_tasks))
         return json_dict

--- a/azure/durable_functions/models/actions/CompoundAction.py
+++ b/azure/durable_functions/models/actions/CompoundAction.py
@@ -14,6 +14,7 @@ class CompoundAction(Action):
 
     def __init__(self, compoundTasks: List[Action]):
         self.compoundTasks = compoundTasks
+
     @property
     @abstractmethod
     def action_type(self) -> int:


### PR DESCRIPTION
This PR moves our Action serialization logic for CompoundTasks (WhenAll/WhenAny) from the Action object constructor to the object serialization method.

This is to ensure that fields which may change during execution, such as `isCanceled`,  are correctly serialized. This ensures, among other things, that Timers can be correctly cancelled.