### PR TITLE
Exclude azure from package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,12 @@ class BuildModule(build.build):
 
 setup(
     name='azure-functions-durable',
-    packages=find_packages(exclude=("tests", "samples","scripts")),
+    packages=find_packages(exclude=[
+        "tests",
+        "samples",
+        "scripts",
+        "azure"
+    ]),
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     description='Durable Functions For Python',


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-functions-python-library/pull/97

Excluded azure from the packages. This fixes an issue where the `azure.function` and other azure package versions do not get updated when a version is specified in the functions requirements.txt file.

The reason for this is that the azure directory has an `__init__.py` file, including azure in the package build overrides the user's dependencies. This is to enable dependency isolation completely.

/cc @gavin-aguiar