### PR TITLE
Upgrade Python Interpreter in CI to 3.7

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ jobs:
       steps:
           - task: UsePythonVersion@0
             inputs:
-                versionSpec: '3.6'
+                versionSpec: '3.7'
           - download: DurablePyCI
           - script: "rm -r ./azure_functions_durable/_manifest"
             displayName: 'Remove _manifest folder'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
     - v*
 
 variables:     
-  python.version: '3.6'
+  python.version: '3.7'
   baseFolder: .
   componentArtifactName: 'azure_functions_durable'
   #componentArtifactName: 'dist'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class BuildModule(build.build):
 
 
 setup(
-    name='azure-functions-durable-test',
+    name='azure-functions-durable',
     packages=find_packages(exclude=[
         "tests",
         "samples",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class BuildModule(build.build):
 
 
 setup(
-    name='azure-functions-durable',
+    name='azure-functions-durable-test',
     packages=find_packages(exclude=[
         "tests",
         "samples",


### PR DESCRIPTION
As in title, given that Python 3.6 is no longer actively support in Azure Functions