### PR TITLE
Detect sub-task completion in constructor

### DIFF
--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -171,6 +171,11 @@ class CompoundTask(TaskBase):
         if len(self.children) == 0:
             self.state = TaskState.SUCCEEDED
 
+        # Sub-tasks may have already completed, so we process them
+        for child in self.children:
+            if not(child.state is TaskState.RUNNING):
+                self.handle_completion(child)
+
     def handle_completion(self, child: TaskBase):
         """Manage sub-task completion events.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class BuildModule(build.build):
 
 
 setup(
-    name='azure-functions-durable-test',
+    name='azure-functions-durable',
     packages=find_packages(exclude=[
         "tests",
         "samples",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class BuildModule(build.build):
 
 
 setup(
-    name='azure-functions-durable',
+    name='azure-functions-durable-test',
     packages=find_packages(exclude=[
         "tests",
         "samples",

--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -24,6 +24,15 @@ def generator_function(context):
 
     return outputs
 
+def generator_function_multi_yield_when_all(context):
+    outputs = []
+
+    task1 = context.call_activity("Hello", "Tokyo")
+    yield context.task_all([task1])
+    result = yield context.task_all([task1])
+
+    return result
+
 def generator_function_no_yield(context):
     outputs = []
 
@@ -280,6 +289,23 @@ def test_tokyo_and_seattle_and_london_state():
     add_hello_action(expected_state, 'Tokyo')
     add_hello_action(expected_state, 'Seattle')
     add_hello_action(expected_state, 'London')
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    assert_valid_schema(result)
+    assert_orchestration_state_equals(expected, result)
+
+
+def test_multi_when_all_yield():
+    context_builder = ContextBuilder('test_simple_function')
+    add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"")
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function_multi_yield_when_all)
+
+    expected_state = base_expected_state(
+        ['Hello Tokyo!'])
+    add_hello_action(expected_state, 'Tokyo')
     expected_state._is_done = True
     expected = expected_state.to_json()
 


### PR DESCRIPTION
Related: https://github.com/Azure/azure-functions-durable-extension/discussions/2213

Currently, the following snippet of code will hang:

```Python
import logging
import azure.durable_functions as df

def orchestrator_function(context: df.DurableOrchestrationContext):

    task = context.call_activity('Hello', "Tokyo")
    result = yield context.task_all([task])
    logging.info(f"result is {result}")
    result = yield context.task_all([task])
    logging.info(f"result is {result}")
    return ""

main = df.Orchestrator.create(orchestrator_function)
```

The reason is taht, by the time we reach the second `task_all`, we have already replayed the event that sets a result for the `task` variable. As a result, we fail to signal that the second `task_all` already has a result.

This kind of error only occurs with compound tasks - atomic tasks like `callActivity` can be `yield`'ed multiple times without failures.

The way to fix this is to add a check in the `WhenAll` and `WhenAny` constructors to see if any of its sub-tasks already have a result. If so, we process them then.