### PR TITLE
Update minimum dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     license='MIT',
     python_requires='>=3.6,<4',
     install_requires=[
-        'azure-functions>=1.2.0',
+        'azure-functions>=1.12.0',
         'aiohttp>=3.6.2',
         'requests==2.*',
         'python-dateutil>=2.8.0',
@@ -59,7 +59,7 @@ setup(
     extra_requires=[
         'flake8==3.7.8',
         'flake8-docstrings==1.5.0',
-        'pytest==5.3.2',
+        'pytest==7.1.2',
         'python-dateutil==2.8.0',
         'requests==2.22.0',
         'jsonschema==3.2.0',
@@ -67,7 +67,7 @@ setup(
         'azure-functions>=1.2.0',
         'nox==2019.11.9',
         'furl==2.1.0',
-        'pytest-asyncio==0.10.0'
+        'pytest-asyncio==0.20.2'
     ],
     include_package_data=True,
     data_files= [


### PR DESCRIPTION
Related: https://github.com/Azure/azure-functions-durable-python/issues/411

This PR updates the minimum project dependencies now that we offer PyStein support. Seems we missed to update these in our latest release. To provide a safety hotfix, let's look to release this _asap_.

The dependencies listed here now closely match those in our own `requirements.txt` file: https://github.com/Azure/azure-functions-durable-python/blob/dev/requirements.txt