### PR TITLE
Export Python V2 experience only if worker supports it

### DIFF
--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -11,12 +11,16 @@ from .models.DurableOrchestrationContext import DurableOrchestrationContext
 from .models.DurableEntityContext import DurableEntityContext
 from .models.RetryOptions import RetryOptions
 from .models.TokenSource import ManagedIdentityTokenSource
-from .decorators import DFApp
 import json
 from pathlib import Path
 import sys
 import warnings
 
+decorators_enabled = True
+try:
+    from .decorators import DFApp
+except ModuleNotFoundError:
+    decorators_enabled = False
 
 def validate_extension_bundles():
     """Raise a warning if host.json contains bundle-range V1.
@@ -70,6 +74,8 @@ __all__ = [
     'DurableOrchestrationContext',
     'ManagedIdentityTokenSource',
     'OrchestrationRuntimeStatus',
-    'RetryOptions',
-    'DFApp'
+    'RetryOptions'
 ]
+
+if decorators_enabled:
+    __all__.append('DFApp')

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -16,11 +16,6 @@ from pathlib import Path
 import sys
 import warnings
 
-decorators_enabled = True
-try:
-    from .decorators import DFApp
-except ModuleNotFoundError:
-    decorators_enabled = False
 
 def validate_extension_bundles():
     """Raise a warning if host.json contains bundle-range V1.
@@ -77,5 +72,9 @@ __all__ = [
     'RetryOptions'
 ]
 
-if decorators_enabled:
+try:
+    # disabling linter on this line because it fails to recognize the conditional export
+    from .decorators import DFApp # noqa
     __all__.append('DFApp')
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
**Context:**
The new programming model change depends on `azure-functions` package version `1.2.0` or greater. This package lives in two places on a user's app: their app dependencies, and their machine's python worker. Using Python's dependency management system, we can ensure that the user's dependencies have the appropriate version of the `azure-functions` package, but we do not have a means to guaranteeing that the Python worker itself is up to date.

When the Python worker does not meet this requirement, the app will throw the following error during startup:

```
Exception: ModuleNotFoundError: No module named 'azure.functions.decorators'. Troubleshooting Guide: https://aka.ms/functions-modulenotfound
Stack:   File "/azure-functions-host/workers/python/3.7/LINUX/X64/azure_functions_worker/dispatcher.py", line 270, in _handle__function_load_request
    func_request.metadata.entry_point)
  File "/azure-functions-host/workers/python/3.7/LINUX/X64/azure_functions_worker/utils/wrappers.py", line 34, in call
    raise extend_exception_message(e, message)
  File "/azure-functions-host/workers/python/3.7/LINUX/X64/azure_functions_worker/utils/wrappers.py", line 32, in call
    return func(*args, **kwargs)
  File "/azure-functions-host/workers/python/3.7/LINUX/X64/azure_functions_worker/loader.py", line 76, in load_function
    mod = importlib.import_module(fullmodname)
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/site/wwwroot/DurableFunctionsHttpStart/__init__.py", line 11, in <module>
    import azure.durable_functions as df
  File "/usr/local/lib/python3.7/site-packages/azure/durable_functions/__init__.py", line 14, in <module>
    from .decorators import DFApp
  File "/usr/local/lib/python3.7/site-packages/azure/durable_functions/decorators/__init__.py", line 4, in <module>
    from .durable_app import DFApp
  File "/usr/local/lib/python3.7/site-packages/azure/durable_functions/decorators/durable_app.py", line 3, in <module>
    from .metadata import OrchestrationTrigger, ActivityTrigger, EntityTrigger,\
  File "/usr/local/lib/python3.7/site-packages/azure/durable_functions/decorators/metadata.py", line 7, in <module>
    from azure.functions.decorators.core import Trigger, InputBinding
```

This error essentially means that the Python worker does not export the decorator dependencies that we need to implement Python V2 support.


**This PR**
As the Python V2 implementation is well isolated from the rest of the SDK, it is possible to only load and export the new programming model experience if the Python worker supports it. This PR does just that - if the programming model implementation fails to load, we do not export it and continue with initialization.