### PR TITLE
Fix error message in `DurableOrchestrationClient.terminate()` when instance is not found

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -437,7 +437,7 @@ class DurableOrchestrationClient:
         switch_statement = {
             202: lambda: None,  # instance in progress
             410: lambda: None,  # instance failed or terminated
-            404: lambda: lambda: f"No instance with ID '{instance_id}' found.",
+            404: lambda: f"No instance with ID '{instance_id}' found.",
         }
 
         has_error_message = switch_statement.get(


### PR DESCRIPTION
Fix #430

I fixed the error message as described in the issue.