### PR TITLE
Add initial blueprint support

### DIFF
--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -58,7 +58,7 @@ def validate_extension_bundles():
 
 
 # Validate that users are not in extension bundles V1
-validate_extension_bundles()
+#validate_extension_bundles()
 
 __all__ = [
     'Orchestrator',
@@ -74,7 +74,8 @@ __all__ = [
 
 try:
     # disabling linter on this line because it fails to recognize the conditional export
-    from .decorators import DFApp # noqa
+    from .decorators import DFApp, BluePrint # noqa
     __all__.append('DFApp')
+    __all__.append('BluePrint')
 except ModuleNotFoundError:
     pass

--- a/azure/durable_functions/__init__.py
+++ b/azure/durable_functions/__init__.py
@@ -58,7 +58,7 @@ def validate_extension_bundles():
 
 
 # Validate that users are not in extension bundles V1
-#validate_extension_bundles()
+validate_extension_bundles()
 
 __all__ = [
     'Orchestrator',

--- a/azure/durable_functions/decorators/__init__.py
+++ b/azure/durable_functions/decorators/__init__.py
@@ -1,8 +1,9 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License.
 """Decorator definitions for Durable Functions."""
-from .durable_app import DFApp
+from .durable_app import DFApp, BluePrint
 
 __all__ = [
-    "DFApp"
+    "DFApp",
+    "BluePrint"
 ]

--- a/azure/durable_functions/decorators/durable_app.py
+++ b/azure/durable_functions/decorators/durable_app.py
@@ -10,19 +10,13 @@ from typing import Union
 from azure.functions import FunctionRegister, TriggerApi, BindingApi, AuthLevel
 from functools import wraps
 
-class DFApp(BluePrint, FunctionRegister):
-    """Durable Functions (DF) app.
-
-    Exports the decorators required to declare and index DF Function-types.
-    """
-    pass
 
 class BluePrint(TriggerApi, BindingApi):
     """Durable Functions (DF) blueprint container.
 
     It allows functions to be declared via trigger and binding decorators,
     but does not automatically index/register these functions.
-    
+
     To register these functions, utilize the `register_functions` method from any
     :class:`FunctionRegister` subclass, such as `DFApp`.
     """
@@ -236,3 +230,12 @@ class BluePrint(TriggerApi, BindingApi):
             return decorator()
 
         return wrap
+
+
+class DFApp(BluePrint, FunctionRegister):
+    """Durable Functions (DF) app.
+
+    Exports the decorators required to declare and index DF Function-types.
+    """
+
+    pass

--- a/azure/durable_functions/decorators/durable_app.py
+++ b/azure/durable_functions/decorators/durable_app.py
@@ -10,11 +10,21 @@ from typing import Union
 from azure.functions import FunctionRegister, TriggerApi, BindingApi, AuthLevel
 from functools import wraps
 
-
-class DFApp(FunctionRegister, TriggerApi, BindingApi):
+class DFApp(BluePrint, FunctionRegister):
     """Durable Functions (DF) app.
 
-    Exports the decorators required to register DF Function-types.
+    Exports the decorators required to declare and index DF Function-types.
+    """
+    pass
+
+class BluePrint(TriggerApi, BindingApi):
+    """Durable Functions (DF) blueprint container.
+
+    It allows functions to be declared via trigger and binding decorators,
+    but does not automatically index/register these functions.
+    
+    To register these functions, utilize the `register_functions` method from any
+    :class:`FunctionRegister` subclass, such as `DFApp`.
     """
 
     def __init__(self,

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -35,6 +35,7 @@ from .utils.entity_utils import EntityId
 from azure.functions._durable_functions import _deserialize_custom_object
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
 
+#from azure.durable_functions.decorators.metadata import ActivityTrigger
 
 class DurableOrchestrationContext:
     """Context of the durable orchestration execution.

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -35,7 +35,6 @@ from .utils.entity_utils import EntityId
 from azure.functions._durable_functions import _deserialize_custom_object
 from azure.durable_functions.constants import DATETIME_STRING_FORMAT
 
-#from azure.durable_functions.decorators.metadata import ActivityTrigger
 
 class DurableOrchestrationContext:
     """Context of the durable orchestration execution.


### PR DESCRIPTION
As in title - exports the new blueprint (i.e splitting functions into multiple files for the Python prog-model V2) class