### PR TITLE
Quote event_name when raising event

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -638,7 +638,7 @@ class DurableOrchestrationClient:
             self, instance_id: str, event_name: str,
             task_hub_name: Optional[str], connection_name: Optional[str]) -> str:
         request_url = f'{self._orchestration_bindings.rpc_base_url}' \
-                      f'instances/{instance_id}/raiseEvent/{quote(event_name)}'
+                      f'instances/{instance_id}/raiseEvent/{quote(event_name, safe="")}'
 
         query: List[str] = []
         if task_hub_name:

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -638,7 +638,7 @@ class DurableOrchestrationClient:
             self, instance_id: str, event_name: str,
             task_hub_name: Optional[str], connection_name: Optional[str]) -> str:
         request_url = f'{self._orchestration_bindings.rpc_base_url}' \
-                      f'instances/{instance_id}/raiseEvent/{event_name}'
+                      f'instances/{instance_id}/raiseEvent/{quote(event_name)}'
 
         query: List[str] = []
         if task_hub_name:

--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from urllib.parse import quote
 from azure.durable_functions.models.actions.SignalEntityAction import SignalEntityAction
 from azure.durable_functions.models.actions.CallEntityAction import CallEntityAction
 from azure.durable_functions.models.Task import TaskBase, TimerTask
@@ -535,7 +536,7 @@ class DurableOrchestrationContext:
             Task to wait for the event
         """
         action = WaitForExternalEventAction(name)
-        task = self._generate_task(action, id_=name)
+        task = self._generate_task(action, id_=quote(name, safe=""))
         return task
 
     def continue_as_new(self, input_: Any):


### PR DESCRIPTION
This should fix Azure/azure-sdk-for-python#30161 by using urllib's quote function on the event name.