### PR TITLE
Support repeatedly calling WhenAny on a progressively smaller list of already scheduled tasks

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -683,7 +683,7 @@ class DurableOrchestrationContext:
                 name = name._function._name
                 return name
             else:
-                if(trigger_type == OrchestrationTrigger):
+                if (trigger_type == OrchestrationTrigger):
                     trigger_type = "OrchestrationTrigger"
                 else:
                     trigger_type = "ActivityTrigger"

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -56,6 +56,14 @@ class TaskBase:
         self.result: Any = None
         self.action_repr: Union[List[Action], Action] = actions
         self.is_played = False
+        self._is_scheduled = False
+
+    @property
+    def is_scheduled(self) -> bool:
+        return self._is_scheduled
+
+    def set_is_scheduled(self, is_scheduled: bool):
+        self._is_scheduled = is_scheduled
 
     @property
     def is_completed(self) -> bool:
@@ -158,7 +166,8 @@ class CompoundTask(TaskBase):
             if isinstance(action_repr, list):
                 child_actions.extend(action_repr)
             else:
-                child_actions.append(action_repr)
+                if not task._is_scheduled:
+                    child_actions.append(action_repr)
         if compound_action_constructor is None:
             self.action_repr = child_actions
         else:  # replay_schema is ReplaySchema.V2
@@ -175,6 +184,10 @@ class CompoundTask(TaskBase):
         for child in self.children:
             if not (child.state is TaskState.RUNNING):
                 self.handle_completion(child)
+
+    @property
+    def is_scheduled(self) -> bool:
+        return all([child.is_scheduled for child in self.children])
 
     def handle_completion(self, child: TaskBase):
         """Manage sub-task completion events.

--- a/azure/durable_functions/models/Task.py
+++ b/azure/durable_functions/models/Task.py
@@ -56,14 +56,14 @@ class TaskBase:
         self.result: Any = None
         self.action_repr: Union[List[Action], Action] = actions
         self.is_played = False
-        self._is_scheduled = False
+        self._is_scheduled_flag = False
 
     @property
-    def is_scheduled(self) -> bool:
-        return self._is_scheduled
+    def _is_scheduled(self) -> bool:
+        return self._is_scheduled_flag
 
-    def set_is_scheduled(self, is_scheduled: bool):
-        self._is_scheduled = is_scheduled
+    def _set_is_scheduled(self, is_scheduled: bool):
+        self._is_scheduled_flag = is_scheduled
 
     @property
     def is_completed(self) -> bool:
@@ -186,8 +186,8 @@ class CompoundTask(TaskBase):
                 self.handle_completion(child)
 
     @property
-    def is_scheduled(self) -> bool:
-        return all([child.is_scheduled for child in self.children])
+    def _is_scheduled(self) -> bool:
+        return all([child._is_scheduled for child in self.children])
 
     def handle_completion(self, child: TaskBase):
         """Manage sub-task completion events.

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -1,4 +1,4 @@
-from azure.durable_functions.models.Task import TaskBase, TaskState, AtomicTask
+from azure.durable_functions.models.Task import TaskBase, TaskState, AtomicTask, CompoundTask
 from azure.durable_functions.models.OrchestratorState import OrchestratorState
 from azure.durable_functions.models.DurableOrchestrationContext import DurableOrchestrationContext
 from typing import Any, List, Optional, Union
@@ -229,7 +229,8 @@ class TaskOrchestrationExecutor:
             task_succeeded = current_task.state is TaskState.SUCCEEDED
             new_task = self.generator.send(
                 task_value) if task_succeeded else self.generator.throw(task_value)
-            self.context._add_to_open_tasks(new_task)
+            if isinstance(new_task, TaskBase) and not(new_task.is_scheduled):
+                self.context._add_to_open_tasks(new_task)
         except StopIteration as stop_exception:
             # the orchestration returned,
             # flag it as such and capture its output
@@ -245,9 +246,17 @@ class TaskOrchestrationExecutor:
                 # user yielded the same task multiple times, continue executing code
                 # until a new/not-previously-yielded task is encountered
                 self.resume_user_code()
-            else:
+            elif not (self.current_task.is_scheduled):
                 # new task is received. it needs to be resolved to a value
                 self.context._add_to_actions(self.current_task.action_repr)
+                self.mark_as_scheduled(self.current_task)
+
+    def mark_as_scheduled(self, task: TaskBase):
+        if isinstance(task, CompoundTask):
+            for task in task.children:
+                self.mark_as_scheduled(task)
+        else:
+            task.set_is_scheduled(True)
 
     def get_orchestrator_state_str(self) -> str:
         """Obtain a JSON-formatted string representing the orchestration's state.

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -229,7 +229,7 @@ class TaskOrchestrationExecutor:
             task_succeeded = current_task.state is TaskState.SUCCEEDED
             new_task = self.generator.send(
                 task_value) if task_succeeded else self.generator.throw(task_value)
-            if isinstance(new_task, TaskBase) and not(new_task.is_scheduled):
+            if isinstance(new_task, TaskBase) and not (new_task._is_scheduled):
                 self.context._add_to_open_tasks(new_task)
         except StopIteration as stop_exception:
             # the orchestration returned,
@@ -246,17 +246,17 @@ class TaskOrchestrationExecutor:
                 # user yielded the same task multiple times, continue executing code
                 # until a new/not-previously-yielded task is encountered
                 self.resume_user_code()
-            elif not (self.current_task.is_scheduled):
+            elif not (self.current_task._is_scheduled):
                 # new task is received. it needs to be resolved to a value
                 self.context._add_to_actions(self.current_task.action_repr)
-                self.mark_as_scheduled(self.current_task)
+                self._mark_as_scheduled(self.current_task)
 
-    def mark_as_scheduled(self, task: TaskBase):
+    def _mark_as_scheduled(self, task: TaskBase):
         if isinstance(task, CompoundTask):
             for task in task.children:
-                self.mark_as_scheduled(task)
+                self._mark_as_scheduled(task)
         else:
-            task.set_is_scheduled(True)
+            task._set_is_scheduled(True)
 
     def get_orchestrator_state_str(self) -> str:
         """Obtain a JSON-formatted string representing the orchestration's state.


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-functions-durable-python/issues/349

Today, we following orchestrator code throws an exception.

```Python
def orchestrator_function(context: df.DurableOrchestrationContext):
    #  Create some tasks
    task1_until = context.current_utc_datetime + datetime.timedelta(seconds=30)
    task1 = context.create_timer(task1_until)
    task2_until = context.current_utc_datetime + datetime.timedelta(seconds=15)
    task2 = context.create_timer(task2_until)
    pending_tasks = [task1, task2]

    #  Yield until first task is completed
    finished_task1 = yield context.task_any(pending_tasks)

    #  Remove completed task from pending tasks
    pending_tasks.remove(finished_task1)

    #  Yield remaining task
    yield context.task_any(pending_tasks)
```

This exception comes from the incorrect assumption that given list of **sub-tasks** will not be `yield`'ed multiple times on **different** parent tasks. In this case, we have two `WhenAny` tasks that both operate on a shared subset of the `pending_tasks` list.

This PR addresses this by ensuring that the second WhenAny only schedules new _actions_ for the set of sub-tasks that have not been already scheduled. Put more simply: we keep track of whether or not an action for a given task was already generated and, if so, we ignore it future attempts at scheduling it.