### PR TITLE
Update GH automation

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -63,7 +63,6 @@ configuration:
               - isOpen
               - not:
                   and:
-                    - isAssignedToSomeone
                     - isLabeled
         then:
           - addLabel:


### PR DESCRIPTION
Removing the `isAssignedToSomeone` condition when adding the `Needs: Triage` label.