### PR TITLE
Prevent already scheduled tasks from being added to opentasks list

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -661,6 +661,9 @@ class DurableOrchestrationContext:
 
     def _add_to_open_tasks(self, task: TaskBase):
 
+        if task._is_scheduled:
+            return
+
         if isinstance(task, AtomicTask):
             if task.id is None:
                 task.id = self._sequence_number

--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -95,6 +95,25 @@ def generator_function_reducing_when_all(context):
     yield context.call_activity("Hello", "London")
     return ""
 
+
+def generator_function_reuse_task_in_whenany(context):
+    task1 = context.call_activity("Hello", "Tokyo")
+    task2 = context.call_activity("Hello", "Seattle")
+    pending_tasks = [task1, task2]
+
+    #  Yield until first task is completed
+    finished_task1 = yield context.task_any(pending_tasks)
+
+    #  Remove completed task from pending tasks
+    pending_tasks.remove(finished_task1)
+
+    task3 = context.call_activity("Hello", "London")
+    tasks = pending_tasks + [task3]
+
+    #  Yield remaining tasks
+    yield context.task_any(tasks)
+    return ""
+
 def generator_function_compound_tasks(context):
     yield context.call_activity("Hello", "Tokyo")
 
@@ -723,6 +742,31 @@ def test_reducing_when_any_pattern():
         [WhenAnyAction(
             [CallActivityAction("Hello", "Seattle"), CallActivityAction("Hello", "Tokyo")]),
             CallActivityAction("Hello", "London")
+        ]
+    ]
+
+    expected_state._is_done = True
+    expected = expected_state.to_json()
+
+    assert_orchestration_state_equals(expected, result)
+
+def test_reducing_when_any_pattern():
+    """Tests that a user can call when_any on a progressively smaller list of already scheduled tasks"""
+    context_builder = ContextBuilder('generator_function_reuse_task_in_whenany', replay_schema=ReplaySchema.V2)
+    add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"")
+    add_hello_completed_events(context_builder, 1, "\"Hello Seattle!\"")
+    add_hello_completed_events(context_builder, 2, "\"Hello London!\"")
+
+    result = get_orchestration_state_result(
+        context_builder, generator_function_reuse_task_in_whenany)
+
+    # this scenario is only supported for V2 replay
+    expected_state = base_expected_state("",replay_schema=ReplaySchema.V2)
+    expected_state._actions = [
+        [WhenAnyAction(
+            [CallActivityAction("Hello", "Seattle"), CallActivityAction("Hello", "Tokyo")]),
+            WhenAnyAction(
+                [CallActivityAction("Hello", "London")])
         ]
     ]
 


### PR DESCRIPTION
Due to the limitations of the out-of-process replay protocol used in the Python SDK, the SDK needs to jump through some hoops when trying creating composite tasks (WhenAll/WhenAny) out of sub-tasks that were already scheduled.

For example, consider the following orchestrator:

```Python
def generator_function_reuse_task_in_whenany(context):
    task1 = context.call_activity("Hello", "Tokyo")
    task2 = context.call_activity("Hello", "Seattle")
    pending_tasks = [task1, task2]

    #  Yield until first task is completed
    finished_task1 = yield context.task_any(pending_tasks)
    # both task 1 and task 2 have been scheduled already

    #  Remove completed task from pending tasks
    pending_tasks.remove(finished_task1)

    task3 = context.call_activity("Hello", "London")
    tasks = pending_tasks + [task3]

    #  We now create a composite task (WhenAny) out of one already scheduled task (either task1 or task2),
    # and a brand new one (task3)
    yield context.task_any(tasks)
    return ""
```

In our out-of-process replay protocol, we have to return a list of all actions taken in the replay. 

*Assuming that the "hello tokyo activity" completes first:**  a naive way to represent the **final** replay of the above orchestrator in this protocol, would be as follows:

```
[
WhenAny(
  [CallActivity("Hello", "Tokyo"), CallActivity("Hello``, "Seattle")],
WhenAny(
  [CallActivity("Hello", "Seattle"), CallActivity("Hello", "London")]
]
```

However, it is assumed that each action in the actions array corresponds to a new task, and above we're scheduling the "Hello Seattle" activity twice, which isn't right. Instead, we need to be clever and exclude the "Hello Seattle" activity from the 2nd WhenAny task, resulting in the following actions array:


```
[
WhenAny(
  [CallActivity("Hello", "Tokyo"), CallActivity("Hello``, "Seattle")],
WhenAny(
  [ CallActivity("Hello", "London")]
]
```

This "fix" isn't perfect, but it's the best we can do given today's protocol. This fix was recently implemented but not correctly, we forgot to also avoid re-registering the "Hello Seattle" activity in the "open tasks" list of the "TaskOrchestrationExecutor" if we know it's been alreayd scheduled. This PR does just that.