### PR TITLE
Add backwards compatibility layer to SettingsApi change

### DIFF
--- a/azure/durable_functions/decorators/durable_app.py
+++ b/azure/durable_functions/decorators/durable_app.py
@@ -11,10 +11,13 @@ from azure.functions import FunctionRegister, TriggerApi, BindingApi, AuthLevel
 from functools import wraps
 
 try:
-    from azure.functions import SettingsApi 
-except ImportError:
+    from azure.functions import SettingsApi
+except ImportError:  # backwards compatibility path
     class SettingsApi:
+        """Backwards compatibility mock of SettingsApi."""
+
         pass
+
 
 class Blueprint(TriggerApi, BindingApi, SettingsApi):
     """Durable Functions (DF) Blueprint container.

--- a/azure/durable_functions/decorators/durable_app.py
+++ b/azure/durable_functions/decorators/durable_app.py
@@ -7,9 +7,14 @@ from azure.durable_functions.entity import Entity
 from azure.durable_functions.orchestrator import Orchestrator
 from azure.durable_functions import DurableOrchestrationClient
 from typing import Union
-from azure.functions import FunctionRegister, TriggerApi, BindingApi, AuthLevel, SettingsApi
+from azure.functions import FunctionRegister, TriggerApi, BindingApi, AuthLevel
 from functools import wraps
 
+try:
+    from azure.functions import SettingsApi 
+except ImportError:
+    class SettingsApi:
+        pass
 
 class Blueprint(TriggerApi, BindingApi, SettingsApi):
     """Durable Functions (DF) Blueprint container.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil==2.8.0
 requests==2.22.0
 jsonschema==3.2.0
 aiohttp==3.7.4
-azure-functions>=1.18.0b3
+azure-functions>=1.11.3b3
 nox==2019.11.9
 furl==2.1.0
 pytest-asyncio==0.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil==2.8.0
 requests==2.22.0
 jsonschema==3.2.0
 aiohttp==3.7.4
-azure-functions>=1.11.3b3
+azure-functions>=1.18.0b3
 nox==2019.11.9
 furl==2.1.0
 pytest-asyncio==0.20.2


### PR DESCRIPTION
The change in [this](https://github.com/Azure/azure-functions-durable-python/pull/463) PR implicitly depends on a beta version of `azure-functions`, so this PR adds backwards compatibility.