### PR TITLE
Fix History Event None Return

### DIFF
--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -165,14 +165,14 @@ class TaskOrchestrationExecutor:
 
             # We provide the ability to deserialize custom objects, because the output of this
             # will be passed directly to the orchestrator as the output of some activity
-            if (event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED 
-                and directive_result.Result is not None):
+            if (event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED and
+                directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if (event_type == HistoryEventType.TASK_COMPLETED 
-                and directive_result.Result is not None):
+            if (event_type == HistoryEventType.TASK_COMPLETED and
+                directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if (event_type == HistoryEventType.EVENT_RAISED
-                and directive_result.Result is not None):
+            if (event_type == HistoryEventType.EVENT_RAISED and
+                directive_result.Result is not None):
                 # TODO: Investigate why the payload is in "Input" instead of "Result"
                 response = json.loads(directive_result.Input,
                                       object_hook=_deserialize_custom_object)

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -167,9 +167,8 @@ class TaskOrchestrationExecutor:
             # will be passed directly to the orchestrator as the output of some activity
             if event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED:
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if event_type == HistoryEventType.TASK_COMPLETED:
-                if directive_result.Result is not None:
-                    return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
+            if event_type == HistoryEventType.TASK_COMPLETED and directive_result.Result is not None:
+                return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
             if event_type == HistoryEventType.EVENT_RAISED:
                 # TODO: Investigate why the payload is in "Input" instead of "Result"
                 response = json.loads(directive_result.Input,

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -165,14 +165,14 @@ class TaskOrchestrationExecutor:
 
             # We provide the ability to deserialize custom objects, because the output of this
             # will be passed directly to the orchestrator as the output of some activity
-            if (event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED and
-                directive_result.Result is not None):
+            if (event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED
+                    and directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if (event_type == HistoryEventType.TASK_COMPLETED and
-                directive_result.Result is not None):
+            if (event_type == HistoryEventType.TASK_COMPLETED
+                    and directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if (event_type == HistoryEventType.EVENT_RAISED and
-                directive_result.Result is not None):
+            if (event_type == HistoryEventType.EVENT_RAISED
+                    and directive_result.Input is not None):
                 # TODO: Investigate why the payload is in "Input" instead of "Result"
                 response = json.loads(directive_result.Input,
                                       object_hook=_deserialize_custom_object)

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -168,7 +168,8 @@ class TaskOrchestrationExecutor:
             if event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED:
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
             if event_type == HistoryEventType.TASK_COMPLETED:
-                return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
+                if directive_result.Result is not None:
+                    return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
             if event_type == HistoryEventType.EVENT_RAISED:
                 # TODO: Investigate why the payload is in "Input" instead of "Result"
                 response = json.loads(directive_result.Input,

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -165,11 +165,14 @@ class TaskOrchestrationExecutor:
 
             # We provide the ability to deserialize custom objects, because the output of this
             # will be passed directly to the orchestrator as the output of some activity
-            if event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED:
+            if (event_type == HistoryEventType.SUB_ORCHESTRATION_INSTANCE_COMPLETED 
+                and directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if event_type == HistoryEventType.TASK_COMPLETED and directive_result.Result is not None:
+            if (event_type == HistoryEventType.TASK_COMPLETED 
+                and directive_result.Result is not None):
                 return json.loads(directive_result.Result, object_hook=_deserialize_custom_object)
-            if event_type == HistoryEventType.EVENT_RAISED:
+            if (event_type == HistoryEventType.EVENT_RAISED
+                and directive_result.Result is not None):
                 # TODO: Investigate why the payload is in "Input" instead of "Result"
                 response = json.loads(directive_result.Input,
                                       object_hook=_deserialize_custom_object)

--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -291,13 +291,13 @@ def add_timer_fired_events(context_builder: ContextBuilder, id_: int, timestamp:
     context_builder.add_orchestrator_started_event()
     context_builder.add_timer_fired_event(id_=id_, fire_at=fire_at)
 
-def add_hello_action(state: OrchestratorState, input_: str):
-    action = CallActivityAction(function_name='Hello', input_=input_)
+def add_hello_action(state: OrchestratorState, input_: str, activity_name="Hello"):
+    action = CallActivityAction(function_name=activity_name, input_=input_)
     state.actions.append([action])
 
 def add_hello_completed_events(
-        context_builder: ContextBuilder, id_: int, result: str, is_played=False):
-    context_builder.add_task_scheduled_event(name='Hello', id_=id_)
+        context_builder: ContextBuilder, id_: int, result: str, is_played=False, activity_name="Hello"):
+    context_builder.add_task_scheduled_event(name=activity_name, id_=id_)
     context_builder.add_orchestrator_completed_event()
     context_builder.add_orchestrator_started_event()
     context_builder.add_task_completed_event(id_=id_, result=result, is_played=is_played)
@@ -388,17 +388,17 @@ def test_call_activity_with_name():
 
 def test_call_activity_with_none_return():
     context_builder = ContextBuilder('test_call_activity_with_none_return')
-    add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"")
-    add_hello_completed_events(context_builder, 1, "\"Hello Seattle!\"")
-    add_hello_completed_events(context_builder, 2, None)
+    add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"", "hello_return_none")
+    add_hello_completed_events(context_builder, 1, "\"Hello Seattle!\"", "hello_return_none")
+    add_hello_completed_events(context_builder, 2, None, "hello_return_none")
     result = get_orchestration_state_result(
         context_builder, generator_function_call_activity_with_none_return)
 
     expected_state = base_expected_state(
         ['Hello Tokyo!', 'Hello Seattle!', None])
-    add_hello_action(expected_state, 'Tokyo')
-    add_hello_action(expected_state, 'Seattle')
-    add_hello_action(expected_state, 'London')
+    add_hello_action(expected_state, 'Tokyo', "hello_return_none")
+    add_hello_action(expected_state, 'Seattle', "hello_return_none")
+    add_hello_action(expected_state, 'London', "hello_return_none")
     expected_state._is_done = True
     expected = expected_state.to_json()
 


### PR DESCRIPTION
Fix issue #454 

When the history event tasks return None, error will be thrown since `None` could not be passed to json.loads.
Add the condition check for history event returns so that if the return is None, the python SDK will just pass `None` to durable extension without json deserialization. 