### PR TITLE
Fix get_status_all() to return all the instances.

### DIFF
--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Union
+from typing import Any, List, Union, Dict, Optional
 
 import aiohttp
 
@@ -29,20 +29,22 @@ async def post_async_request(url: str, data: Any = None) -> List[Union[int, Any]
             return [response.status, data]
 
 
-async def get_async_request(url: str) -> List[Any]:
+async def get_async_request(url: str, headers: Dict[Any, Any] = None) -> List[Any]:
     """Get the data from the url provided.
 
     Parameters
     ----------
     url: str
         url to get the data from
+    headers: Dict[str, str]
+        headers to send with the request
 
     Returns
     -------
     [int, Any]
         Tuple with the Response status code and the data returned from the request
     """
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=headers) as session:
         async with session.get(url) as response:
             data = await response.json(content_type=None)
             if data is None:


### PR DESCRIPTION
WARNING: THIS PATCH IS JUST TO HINT ABOUT THE EXISTING ISSUE. IT NEEDS SOME ADDITIONAL WORK FROM THE MAINTAINERS TO BE MERGED.

get_status_all() function is meant to return all the instances of the durable function. However, if there is more than 100 instances, the function will not return all of them.

This is due to the fact that the if more than 100 instances exists, a continuation token is returned in the response header which is called x-ms-continuation-token. Please see:
https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-api#response-2

If we set the continuation token in the next request header, we get the next 100 instances. This is essentially what we want to do in this patch: to supply x-ms-continuation-token if it is given from the API.

Please note that in DurableOrchestrationClient, I have used "response.header" while this attribute does not exist in the "response" object. Adding it is beyond my knowledge and requires maintainer's attention.