### PR TITLE
Bugfix: Support returning json serializable objects from an orchestrator function

### DIFF
--- a/azure/durable_functions/models/OrchestratorState.py
+++ b/azure/durable_functions/models/OrchestratorState.py
@@ -76,7 +76,7 @@ class OrchestratorState:
         """Get the Replay Schema represented in this OrchestratorState payload."""
         return self._replay_schema.value
 
-    def to_json(self) -> Dict[str, Union[str, int, Any]]:
+    def to_json(self) -> Dict[str, Any]:
         """Convert object into a json dictionary.
 
         Returns
@@ -84,7 +84,7 @@ class OrchestratorState:
         Dict[str, Any]
             The instance of the class converted into a json dictionary
         """
-        json_dict: Dict[str, Union[str, int]] = {}
+        json_dict: Dict[str, Any] = {}
         add_attrib(json_dict, self, '_is_done', 'isDone')
         if self._replay_schema != ReplaySchema.V1:
             add_attrib(json_dict, self, 'schema_version', 'schemaVersion')

--- a/azure/durable_functions/models/OrchestratorState.py
+++ b/azure/durable_functions/models/OrchestratorState.py
@@ -5,6 +5,7 @@ from azure.durable_functions.models.ReplaySchema import ReplaySchema
 
 from .utils.json_utils import add_attrib
 from azure.durable_functions.models.actions.Action import Action
+from azure.functions._durable_functions import _serialize_custom_object
 
 
 class OrchestratorState:
@@ -75,7 +76,7 @@ class OrchestratorState:
         """Get the Replay Schema represented in this OrchestratorState payload."""
         return self._replay_schema.value
 
-    def to_json(self) -> Dict[str, Union[str, int]]:
+    def to_json(self) -> Dict[str, Union[str, int, Any]]:
         """Convert object into a json dictionary.
 
         Returns
@@ -113,4 +114,4 @@ class OrchestratorState:
             The instance of the object in json string format
         """
         json_dict = self.to_json()
-        return json.dumps(json_dict)
+        return json.dumps(json_dict, default=_serialize_custom_object)


### PR DESCRIPTION
Currently you can send an arbitrary json-serializable to a sub orchestrator, but that sub orchestrator cannot return the same object.

This because the input param's serializer [falls back to using a generic custom obj serializer](https://github.com/Azure/azure-functions-durable-python/blob/e1edc12db018e1bf4aef0bd86a7adba922c33efa/azure/durable_functions/models/actions/CallSubOrchestratorAction.py#L16), but the orchestrator return value doesn't get the same special treatment. 

## Fixes in this PR
- Pass in the same serializer to both invocations of `json.dumps()`. This let's custom objects get correctly returned.
- Fix the type hinting on `OrchestratorState.to_json()` since it can set the value of the dictionary to `self._output` and `self._error`, both of which are typehinted as being of `Any` type 

I suspect (but haven't verified) that this also fixes a similar bug that prevents the custom_status from being set to a custom json-serializable object

## Missing from this PR
Tests. Sorry for not adding them in but I didn't feel like learning the new test framework for this PR. I tested this manually, and if you guys want unit tests for this then I'm hoping it's trivial for you folks to add.

## More context
Without this fix, returning a custom JSON-serializable method results in this error:

```
[2024-03-09T17:44:24.704Z] Executed 'Functions.some_orchestrator' (Failed, Id=605291c9-282c-48eb-986e-d28307099dc6, Duration=228ms)
[2024-03-09T17:44:24.708Z] System.Private.CoreLib: Exception while executing function: Functions.some_orchestrator. System.Private.CoreLib: Orchestrator function 'some_orchestrator' failed: One or more errors occurred. (Result: Failure
Exception: TypeError: Object of type MyCustomObjectis not JSON serializable
Stack:   File "C:\Program Files\Microsoft\Azure Functions Core Tools\workers\python\3.10\WINDOWS\X64\azure_functions_worker\dispatcher.py", line 495, in _handle__invocation_request      
    call_result = await self._loop.run_in_executor(
  File "C:\Python310\lib\concurrent\futures\thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "C:\Program Files\Microsoft\Azure Functions Core Tools\workers\python\3.10\WINDOWS\X64\azure_functions_worker\dispatcher.py", line 768, in _run_sync_func
    return ExtensionManager.get_sync_invocation_wrapper(context,
  File "C:\Program Files\Microsoft\Azure Functions Core Tools\workers\python\3.10\WINDOWS\X64\azure_functions_worker\extension.py", line 215, in _raw_invocation_wrapper
    result = function(**args)
  File "C:\Users\...\fnOrchestrator\.venv\lib\site-packages\azure\durable_functions\orchestrator.py", line 69, in handle
    return Orchestrator(fn).handle(DurableOrchestrationContext.from_json(context_body))
  File "C:\Users\...\fnOrchestrator\.venv\lib\site-packages\azure\durable_functions\orchestrator.py", line 47, in handle
    return self.task_orchestration_executor.execute(context, context.histories, self.fn)
  File "C:\Users\...\fnOrchestrator\.venv\lib\site-packages\azure\durable_functions\models\TaskOrchestrationExecutor.py", line 104, in execute
    return self.get_orchestrator_state_str()
  File "C:\Users\...\fnOrchestrator\.venv\lib\site-packages\azure\durable_functions\models\TaskOrchestrationExecutor.py", line 296, in get_orchestrator_state_str
    return state.to_json_string()
  File "C:\Users\...\fnOrchestrator\.venv\lib\site-packages\azure\durable_functions\models\OrchestratorState.py", line 121, in to_json_string
    return json.dumps(json_dict)
  File "C:\Python310\lib\json\__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "C:\Python310\lib\json\encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "C:\Python310\lib\json\encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "C:\Python310\lib\json\encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
).
```