### PR TITLE
Update Orchestration Ouput Return error

### DIFF
--- a/azure/durable_functions/models/OrchestratorState.py
+++ b/azure/durable_functions/models/OrchestratorState.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Any, Dict, Optional, Union
+from typing import List, Any, Dict, Optional
 
 from azure.durable_functions.models.ReplaySchema import ReplaySchema
 

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -276,6 +276,16 @@ class TaskOrchestrationExecutor:
             message contains in it the string representation of the orchestration's
             state
         """
+        if(self.output):
+            try:
+                # Attempt to serialize the output. If serialization fails, raise an
+                # error indicating that the orchestration output is not serializable,
+                # which is not permitted in durable Python functions.
+                json.dumps(self.output)
+            except Exception as e:
+                self.output = None
+                self.exception = e
+        
         state = OrchestratorState(
             is_done=self.orchestration_invocation_succeeded,
             actions=self.context._actions,

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -285,7 +285,7 @@ class TaskOrchestrationExecutor:
             except Exception as e:
                 self.output = None
                 self.exception = e
-        
+
         state = OrchestratorState(
             is_done=self.orchestration_invocation_succeeded,
             actions=self.context._actions,

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -276,7 +276,7 @@ class TaskOrchestrationExecutor:
             message contains in it the string representation of the orchestration's
             state
         """
-        if(self.output):
+        if(self.output is not None):
             try:
                 # Attempt to serialize the output. If serialization fails, raise an
                 # error indicating that the orchestration output is not serializable,


### PR DESCRIPTION
Fix issue #428 

If the orchestrator output includes any type that cannot be serialized into JSON, it will trigger a non-deterministic error. This occurs because the orchestration state must be serialized before it is sent to the durable extension. If there is a serialization issue, the extension cannot replay correctly from this corrupted state, thus treating the situation as non-deterministic. The fix in this PR is to verify whether the orchestration output is serializable. If it is not, an exception will be thrown to indicate that this type of return is not accepted in durable Python.

Noting E2E test,

![image](https://github.com/Azure/azure-functions-durable-python/assets/110135109/31f7b76c-11ee-42f4-9d34-e15d8dbec93f)

Orchestrator return includes a exception object. 

Former return:
![image](https://github.com/Azure/azure-functions-durable-python/assets/110135109/804e30d1-f838-41cd-9748-2b17b90d569a)


Return with changes in this PR: 
![image](https://github.com/Azure/azure-functions-durable-python/assets/110135109/72384a11-91ad-4b2e-9b7c-4d9fb32b5385)
