### PR TITLE
chore: add py.typed

### DIFF
--- a/azure/durable_functions/py.typed
+++ b/azure/durable_functions/py.typed
@@ -1,0 +1,2 @@
+# this file is a placeholder used by static type checkers (e.g. MyPy) to determine that this library is typed. Its required for typing analysis to work. 
+# See: https://peps.python.org/pep-0561/ for context. 


### PR DESCRIPTION
This PR adds a `py.typed` file, which is currently missing. It will fix the following type of error raised by MyPy and similar tools:

<img width="795" alt="Screenshot 2024-05-17 at 12 08 53" src="https://github.com/Azure/azure-functions-durable-python/assets/30733348/1cff5051-8d5b-40bd-b995-84dc3fd91fb0">
