### PR TITLE
Add dev branch to official build schedule

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -20,6 +20,7 @@ schedules:
   branches:
     include:
     - main
+    - dev
   always: true
 
 resources:


### PR DESCRIPTION
As in title. This will ensure we catch regressions in the dev branch, which is one of our main merge targets