### PR TITLE
Remove confusing fake auth code string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from azure.durable_functions.models.DurableOrchestrationBindings import \
 
 TASK_HUB_NAME = "DurableFunctionsHub"
 BASE_URL = "http://localhost:7071/runtime/webhooks/durabletask"
-AUTH_CODE = "iDFeaQCSAIuXoodl6/w3rdvHZ6Nl7yJwRrHfeInNWDJjuiunhxk8dQ=="
+AUTH_CODE = "NOT-REAL-AUTH"
 
 
 def get_binding_string():


### PR DESCRIPTION
The unit test (which don't connect to real storage) have a fake but ultimately realistic auth code string. To avoid false alarms, I'm removing that auth code variable with a constant.