### PR TITLE
Handle exceptions when no message is present

### DIFF
--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -285,13 +285,19 @@ class TaskOrchestrationExecutor:
             except Exception as e:
                 self.output = None
                 self.exception = e
+        
+        exception_str = None
+        if self.exception is not None:
+            exception_str = str(self.exception)
+            if not exception_str:
+                exception_str = str(type(self.exception))
 
         state = OrchestratorState(
             is_done=self.orchestration_invocation_succeeded,
             actions=self.context._actions,
             output=self.output,
             replay_schema=self.context._replay_schema,
-            error=None if self.exception is None else (str(type(self.exception)) if not str(self.exception) else str(self.exception)),
+            error=exception_str,
             custom_status=self.context.custom_status
         )
 

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -285,7 +285,7 @@ class TaskOrchestrationExecutor:
             except Exception as e:
                 self.output = None
                 self.exception = e
-        
+
         exception_str = None
         if self.exception is not None:
             exception_str = str(self.exception)

--- a/azure/durable_functions/models/TaskOrchestrationExecutor.py
+++ b/azure/durable_functions/models/TaskOrchestrationExecutor.py
@@ -291,7 +291,7 @@ class TaskOrchestrationExecutor:
             actions=self.context._actions,
             output=self.output,
             replay_schema=self.context._replay_schema,
-            error=None if self.exception is None else str(self.exception),
+            error=None if self.exception is None else (str(type(self.exception)) if not str(self.exception) else str(self.exception)),
             custom_status=self.context.custom_status
         )
 


### PR DESCRIPTION
Resolves #529 
When no exception message is present in user-thrown exception, pass the string form of the exception type name to the WebJobs extension instead