### PR TITLE
Add support to send trace information to the WebJobs extension

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -77,6 +77,8 @@ class DurableOrchestrationClient:
         span_context = current_span.get_span_context()
 
         # Get the traceparent and tracestate from the span context
+        # Follows the W3C Trace Context specification for traceparent
+        # https://www.w3.org/TR/trace-context/#traceparent-header
         trace_id = format(span_context.trace_id, '032x')
         span_id = format(span_context.span_id, '016x')
         trace_flags = format(span_context.trace_flags, '02x')

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -83,7 +83,7 @@ class DurableOrchestrationClient:
         span_id = format(span_context.span_id, '016x')
         trace_flags = format(span_context.trace_flags, '02x')
         trace_parent = f"00-{trace_id}-{span_id}-{trace_flags}"
-        
+
         trace_state = span_context.trace_state
 
         response: List[Any] = await self._post_async_request(

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -47,7 +47,9 @@ class DurableOrchestrationClient:
     async def start_new(self,
                         orchestration_function_name: str,
                         instance_id: Optional[str] = None,
-                        client_input: Optional[Any] = None) -> str:
+                        client_input: Optional[Any] = None,
+                        trace_parent: str = None,
+                        trace_state: str = None) -> str:
         """Start a new instance of the specified orchestrator function.
 
         If an orchestration instance with the specified ID already exists, the
@@ -72,7 +74,10 @@ class DurableOrchestrationClient:
             instance_id=instance_id, orchestration_function_name=orchestration_function_name)
 
         response: List[Any] = await self._post_async_request(
-            request_url, self._get_json_input(client_input))
+            request_url,
+            self._get_json_input(client_input),
+            trace_parent,
+            trace_state)
 
         status_code: int = response[0]
         if status_code <= 202 and response[1]:

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -48,8 +48,8 @@ class DurableOrchestrationClient:
                         orchestration_function_name: str,
                         instance_id: Optional[str] = None,
                         client_input: Optional[Any] = None,
-                        trace_parent: str = None,
-                        trace_state: str = None) -> str:
+                        trace_parent: Optional[str] = None,
+                        trace_state: Optional[str] = None) -> str:
         """Start a new instance of the specified orchestrator function.
 
         If an orchestration instance with the specified ID already exists, the
@@ -64,6 +64,10 @@ class DurableOrchestrationClient:
             the Durable Functions extension will generate a random GUID (recommended).
         client_input : Optional[Any]
             JSON-serializable input value for the orchestrator function.
+        trace_parent : str
+            The traceparent header to send with the request.
+        trace_state : str
+            The tracestate header to send with the request.
 
         Returns
         -------

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -83,7 +83,7 @@ class DurableOrchestrationClient:
         trace_parent = f"00-{trace_id}-{span_id}-{trace_flags}"
         
         trace_state = span_context.trace_state
-        
+
         response: List[Any] = await self._post_async_request(
             request_url,
             self._get_json_input(client_input),

--- a/azure/durable_functions/models/DurableOrchestrationClient.py
+++ b/azure/durable_functions/models/DurableOrchestrationClient.py
@@ -4,6 +4,7 @@ from typing import List, Any, Optional, Dict, Union
 from time import time
 from asyncio import sleep
 from urllib.parse import urlparse, quote
+from opentelemetry import trace
 
 import azure.functions as func
 
@@ -47,9 +48,7 @@ class DurableOrchestrationClient:
     async def start_new(self,
                         orchestration_function_name: str,
                         instance_id: Optional[str] = None,
-                        client_input: Optional[Any] = None,
-                        trace_parent: Optional[str] = None,
-                        trace_state: Optional[str] = None) -> str:
+                        client_input: Optional[Any] = None) -> str:
         """Start a new instance of the specified orchestrator function.
 
         If an orchestration instance with the specified ID already exists, the
@@ -64,10 +63,6 @@ class DurableOrchestrationClient:
             the Durable Functions extension will generate a random GUID (recommended).
         client_input : Optional[Any]
             JSON-serializable input value for the orchestrator function.
-        trace_parent : str
-            The traceparent header to send with the request.
-        trace_state : str
-            The tracestate header to send with the request.
 
         Returns
         -------
@@ -77,6 +72,18 @@ class DurableOrchestrationClient:
         request_url = self._get_start_new_url(
             instance_id=instance_id, orchestration_function_name=orchestration_function_name)
 
+        # Get the current span
+        current_span = trace.get_current_span()
+        span_context = current_span.get_span_context()
+
+        # Get the traceparent and tracestate from the span context
+        trace_id = format(span_context.trace_id, '032x')
+        span_id = format(span_context.span_id, '016x')
+        trace_flags = format(span_context.trace_flags, '02x')
+        trace_parent = f"00-{trace_id}-{span_id}-{trace_flags}"
+        
+        trace_state = span_context.trace_state
+        
         response: List[Any] = await self._post_async_request(
             request_url,
             self._get_json_input(client_input),

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -3,7 +3,7 @@ from typing import Any, List, Union
 import aiohttp
 
 
-async def post_async_request(url: str, data: Any = None) -> List[Union[int, Any]]:
+async def post_async_request(url: str, data: Any = None, trace_parent: str = None, trace_state: str = None) -> List[Union[int, Any]]:
     """Post request with the data provided to the url provided.
 
     Parameters
@@ -20,7 +20,11 @@ async def post_async_request(url: str, data: Any = None) -> List[Union[int, Any]
     """
     async with aiohttp.ClientSession() as session:
         async with session.post(url,
-                                json=data) as response:
+                                json=data,
+                                headers={
+                                    "traceparent": trace_parent,
+                                    "tracestate": trace_state
+                                }) as response:
             # We disable aiohttp's input type validation
             # as the server may respond with alternative
             # data encodings. This is potentially unsafe.

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -28,9 +28,9 @@ async def post_async_request(url: str,
     async with aiohttp.ClientSession() as session:
         headers = {}
         if trace_parent:
-            headers["traceparent"] = trace_parent
+            headers["x-client-traceparent"] = trace_parent
         if trace_state:
-            headers["tracestate"] = trace_state
+            headers["x-client-tracestate"] = trace_state
         async with session.post(url, json=data, headers=headers) as response:
             # We disable aiohttp's input type validation
             # as the server may respond with alternative

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -12,6 +12,10 @@ async def post_async_request(url: str, data: Any = None, trace_parent: str = Non
         url to make the post to
     data: Any
         object to post
+    trace_parent: str
+        traceparent header to send with the request
+    trace_state: str
+        tracestate header to send with the request
 
     Returns
     -------
@@ -19,12 +23,12 @@ async def post_async_request(url: str, data: Any = None, trace_parent: str = Non
         Tuple with the Response status code and the data returned from the request
     """
     async with aiohttp.ClientSession() as session:
-        async with session.post(url,
-                                json=data,
-                                headers={
-                                    "traceparent": trace_parent,
-                                    "tracestate": trace_state
-                                }) as response:
+        headers = {}
+        if trace_parent:
+            headers["traceparent"] = trace_parent
+        if trace_state:
+            headers["tracestate"] = trace_state
+        async with session.post(url, json=data, headers=headers) as response:
             # We disable aiohttp's input type validation
             # as the server may respond with alternative
             # data encodings. This is potentially unsafe.

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -3,7 +3,10 @@ from typing import Any, List, Union
 import aiohttp
 
 
-async def post_async_request(url: str, data: Any = None, trace_parent: str = None, trace_state: str = None) -> List[Union[int, Any]]:
+async def post_async_request(url: str,
+                             data: Any = None,
+                             trace_parent: str = None,
+                             trace_state: str = None) -> List[Union[int, Any]]:
     """Post request with the data provided to the url provided.
 
     Parameters

--- a/azure/durable_functions/models/utils/http_utils.py
+++ b/azure/durable_functions/models/utils/http_utils.py
@@ -28,9 +28,9 @@ async def post_async_request(url: str,
     async with aiohttp.ClientSession() as session:
         headers = {}
         if trace_parent:
-            headers["x-client-traceparent"] = trace_parent
+            headers["traceparent"] = trace_parent
         if trace_state:
-            headers["x-client-tracestate"] = trace_state
+            headers["tracestate"] = trace_state
         async with session.post(url, json=data, headers=headers) as response:
             # We disable aiohttp's input type validation
             # as the server may respond with alternative

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ furl==2.1.0
 pytest-asyncio==0.20.2
 autopep8
 types-python-dateutil
+opentelemetry-api

--- a/tests/models/test_DurableOrchestrationClient.py
+++ b/tests/models/test_DurableOrchestrationClient.py
@@ -67,7 +67,7 @@ class MockRequest:
         assert url == self._expected_url
         return self._response
 
-    async def post(self, url: str, data: Any = None):
+    async def post(self, url: str, data: Any = None, trace_parent: str = None, trace_state: str = None):
         assert url == self._expected_url
         return self._response
 


### PR DESCRIPTION
This PR introduces support for propagating trace information to the WebJobs extension by getting the `traceparent` and `tracestate` information in the `start_new` method by accessing the "current span" information. `traceparent` and `tracestate` are then forwarded to the `post_async_request` method, which now accepts `trace_parent` and `trace_state` parameters in http_utils.py to include them in the outgoing request. `trace_parent` and `trace_state` parameters are now set as the headers in the POST request to the WebJobs extension.


In the example below, I used the HTTP trigger's `traceparent` and `tracestate` as the parent context of a new span that I created. I then set that new span as the current span before calling `start_new()`.

Note: I followed the [Azure Function OpenTelemetry](https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto?tabs=app-insights&pivots=programming-language-python) set up in this example which is also emitting spans for storage requests and that's why there are spans for storage operations. 

requirements.txt
```
azure-functions
azure-functions-durable
azure-monitor-opentelemetry
opentelemetry-api
opentelemetry-sdk
```

Client Function code
``` python
import azure.functions as func
import azure.durable_functions as df
import opentelemetry.context as context_api

from azure.monitor.opentelemetry import configure_azure_monitor
from opentelemetry import trace
from opentelemetry.trace import SpanKind
from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator

configure_azure_monitor()
tracer = trace.get_tracer(__name__)

myApp = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)

# An HTTP-triggered function with a Durable Functions client binding
@myApp.route(route="orchestrators/{functionName}")
@myApp.durable_client_input(client_name="client")
async def http_start(req: func.HttpRequest, client, context: func.Context):
    function_name = req.route_params.get('functionName')

    # Extract the traceparent and tracestate from the context
    parent = {
        "traceparent": context.trace_context.trace_parent,
        "tracestate": context.trace_context.trace_state
    }
    parent_context = TraceContextTextMapPropagator().extract(parent)

    # Create a new span with the extracted parent context
    with tracer.start_as_current_span(
            "myCustomSpan",
            context=parent_context,
            kind=SpanKind.CLIENT) as span:
        
        span.set_attribute("az.namespace", "app")

        instance_id = await client.start_new(function_name)
        response = client.create_check_status_response(req, instance_id)
    return response
```

<img width="644" alt="image" src="https://github.com/user-attachments/assets/b863396a-a06e-4bd1-9694-00c717c22124" />



