### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,20 @@ pip install -e $REPOSITORY_ROOT/
 ```
 where REPOSITORY_ROOT is the root folder of the azure-functions-durable-python repository 
 
-7. Set breakpoints and click Run -> Start Debugging in VS Code. This should internally start the Azure Function using `func host start` command.
+7. Set breakpoints and click Run -> Start Debugging in VS Code. This should internally start the Azure Function using `func host start` command. If the breakpoints are not getting hit, check to make sure that you have set `justMyCode: false` in the function app's .vscode/launch.json.
+
+```
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      ...
+      "justMyCode": false
+      ...
+    }
+  ]
+}
+```
 
 ### Debugging end-to-end
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,11 @@ where REPOSITORY_ROOT is the root folder of the azure-functions-durable-python r
 
 If you want to debug into the Durable Task or any of the .NET bits, follow instructions below:
 
-1. Open the Azure Storage Explorer and connect to the local storage emulator or the storage account you are using.
-2. Make sure the Durable Python debugging is setup already and the debugger has started the `func` process.
-3. In the VSCode editor for DurableTask, click Debug -> .NET Core Attach Process and search for `func host start` process and attach to it.
-4. Add a breakpoint in both editors and continue debugging.
+1. If you would like to debug a custom local WebJobs extension package then create the custom package, place it in a local directory, and then run `func extensions install --package Microsoft.Azure.WebJobs.Extensions.DurableTask --version <VERSION>`. If you update the version while debugging and the new version doesn't get picked up, then try running `func extensions install` to get the new changes.
+2. Open the Azure Storage Explorer and connect to the local storage emulator or the storage account you are using.
+3. Make sure the Durable Python debugging is setup already and the debugger has started the `func` process.
+4. In the VSCode editor for DurableTask, click Debug -> .NET Core Attach Process, search for `func host start` process and attach to it. If you are using Visual Studio, click Debug -> Attach to Process, search for the `func` process and attach to it.
+5. Add a breakpoint in both editors and continue debugging.
 
 ## Testing changes locally (Windows)
 


### PR DESCRIPTION
Adding information to CONTRIBUTING.md about how you might need to add `justMyCode: false` to launch.json if your breakpoints are not getting hit and additional steps to debug the WebJobs extension.