### PR TITLE
Codeowners - correct syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,4 @@
 # For all file changes, github would automatically include the following people in the PRs.
 #
 
-* @nytian
-* @bachuv
-* @andystaples
-* @cgillum
+* @nytian @cgillum @bachuv @andystaples


### PR DESCRIPTION
CODEOWNERS file syntax specifies that for each rule, multiple users should exist on the same line. 
The current syntax means @cgillum becomes the only owner as rules are applied sequentially
Correct this. 