### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ azure-functions>=1.11.3b3
 nox==2019.11.9
 furl==2.1.0
 pytest-asyncio==0.20.2
+opentelemetry-distro==0.53b1
 autopep8
 types-python-dateutil
-opentelemetry-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ azure-functions>=1.11.3b3
 nox==2019.11.9
 furl==2.1.0
 pytest-asyncio==0.20.2
-opentelemetry-distro==0.53b1
 autopep8
 types-python-dateutil
+opentelemetry-api==1.32.1
+opentelemetry-sdk==1.32.1


### PR DESCRIPTION
The changes for distributed tracing introduced in #540 require opentelemetry-sdk to be present in order to compile. Still exploring why the pipeline passed without catching this, but this PR will add the needed package to requirements.txt