### PR TITLE
Update unit testing for compatibility with worker

### DIFF
--- a/azure/durable_functions/entity.py
+++ b/azure/durable_functions/entity.py
@@ -3,8 +3,6 @@ from .models.entities import OperationResult, EntityState
 from datetime import datetime
 from typing import Callable, Any, List, Dict
 
-import azure.functions as func
-
 
 class InternalEntityException(Exception):
     """Framework-internal Exception class (for internal use only)."""

--- a/azure/durable_functions/entity.py
+++ b/azure/durable_functions/entity.py
@@ -12,43 +12,6 @@ class InternalEntityException(Exception):
     pass
 
 
-class EntityHandler(Callable):
-    """Durable Entity Handler.
-
-    A callable class that wraps the user defined entity function for execution by the Python worker
-    and also allows access to the original method for unit testing
-    """
-
-    def __init__(self, func: Callable[[DurableEntityContext], None]):
-        """
-        Create a new entity handler for the user defined entity function.
-
-        Parameters
-        ----------
-        func: Callable[[DurableEntityContext], None]
-            The user defined entity function.
-        """
-        self.entity_function = func
-
-    def __call__(self, context: func.EntityContext) -> str:
-        """
-        Handle the execution of the user defined entity function.
-
-        Parameters
-        ----------
-        context : func.EntityContext
-            The DF entity context
-        """
-        # It is not clear when the context JSON would be found
-        # inside a "body"-key, but this pattern matches the
-        # orchestrator implementation, so we keep it for safety.
-        context_body = getattr(context, "body", None)
-        if context_body is None:
-            context_body = context
-        ctx, batch = DurableEntityContext.from_json(context_body)
-        return Entity(self.entity_function).handle(ctx, batch)
-
-
 class Entity:
     """Durable Entity Class.
 
@@ -131,10 +94,22 @@ class Entity:
 
         Returns
         -------
-        EntityHandler
-            Entity Handler callable for the newly created entity client
+        Callable[[Any], str]
+            Handle function of the newly created entity client
         """
-        return EntityHandler(fn)
+        def handle(context) -> str:
+            # It is not clear when the context JSON would be found
+            # inside a "body"-key, but this pattern matches the
+            # orchestrator implementation, so we keep it for safety.
+            context_body = getattr(context, "body", None)
+            if context_body is None:
+                context_body = context
+            ctx, batch = DurableEntityContext.from_json(context_body)
+            return Entity(fn).handle(ctx, batch)
+
+        handle.entity_function = fn
+
+        return handle
 
     def _elapsed_milliseconds_since(self, start_time: datetime) -> int:
         """Calculate the elapsed time, in milliseconds, from the start_time to the present.

--- a/azure/durable_functions/orchestrator.py
+++ b/azure/durable_functions/orchestrator.py
@@ -11,41 +11,6 @@ from .models import DurableOrchestrationContext
 import azure.functions as func
 
 
-class OrchestrationHandler(Callable):
-    """Durable Orchestration Handler.
-
-    A callable class that wraps the user defined generator function for execution
-    by the Python worker and also allows access to the original method for unit testing
-    """
-
-    def __init__(self, func: Callable[[DurableOrchestrationContext], Generator[Any, Any, Any]]):
-        """
-        Create a new orchestrator handler for the user defined orchestrator function.
-
-        Parameters
-        ----------
-        func: Callable[[DurableOrchestrationContext], Generator[Any, Any, Any]]
-            The user defined orchestrator function.
-        """
-        self.orchestrator_function = func
-
-    def __call__(self, context: func.OrchestrationContext) -> str:
-        """
-        Handle the execution of the user defined orchestrator function.
-
-        Parameters
-        ----------
-        context : func.OrchestrationContext
-            The DF orchestration context
-        """
-        context_body = getattr(context, "body", None)
-        if context_body is None:
-            context_body = context
-        return Orchestrator(self.orchestrator_function).handle(
-            DurableOrchestrationContext.from_json(context_body)
-        )
-
-
 class Orchestrator:
     """Durable Orchestration Class.
 
@@ -93,7 +58,16 @@ class Orchestrator:
 
         Returns
         -------
-        OrchestrationHandler
-            Orchestration handler callable class for the newly created orchestration client
+        Callable[[Any], str]
+            Handle function of the newly created orchestration client
         """
-        return OrchestrationHandler(fn)
+
+        def handle(context: func.OrchestrationContext) -> str:
+            context_body = getattr(context, "body", None)
+            if context_body is None:
+                context_body = context
+            return Orchestrator(fn).handle(DurableOrchestrationContext.from_json(context_body))
+
+        handle.orchestrator_function = fn
+
+        return handle

--- a/samples-v2/function_chaining/tests/test_my_orchestrator.py
+++ b/samples-v2/function_chaining/tests/test_my_orchestrator.py
@@ -31,7 +31,7 @@ class TestFunction(unittest.TestCase):
     expected_activity_calls = [call('say_hello', 'Tokyo'),
                                call('say_hello', 'Seattle'),
                                call('say_hello', 'London')]
-    
+
     self.assertEqual(context.call_activity.call_count, 3)
     self.assertEqual(context.call_activity.call_args_list, expected_activity_calls)
     self.assertEqual(values[3], ["Hello Tokyo!", "Hello Seattle!", "Hello London!"])


### PR DESCRIPTION
Unfortunately, this very cool Callable syntax I had in the original unit testing PR is not compatible with the Python worker, as it uses typing.get_type_hints on whatever value t has for the user function, and get_type_hints does not work on class instances, even if those instances are Callables. 

Reverting to the more primative approach, where we simply add the original user functions as properties on the wrapped methods, instead of a dedicated and documented class for now. 