### PR TITLE
Bump minimum Python version to 3.9

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ jobs:
       steps:
           - task: UsePythonVersion@0
             inputs:
-                versionSpec: '3.7'
+                versionSpec: '3.9'
           - download: DurablePyCI
           - script: "rm -r ./azure_functions_durable/_manifest"
             displayName: 'Remove _manifest folder'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
 
     - script: |
         pip install pytest pytest-azurepipelines
-        pytest
+        pytest --ignore=samples-v2
       displayName: 'pytest'
     - task: ManifestGeneratorTask@0
       displayName: "SBOM Generation Task"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
     - v*
 
 variables:     
-  python.version: '3.7'
+  python.version: '3.9'
   baseFolder: .
   componentArtifactName: 'azure_functions_durable'
   #componentArtifactName: 'dist'

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.7.x'
+            versionSpec: '3.8.x'
         - script: |
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.8.x'
+            versionSpec: '3.9.x'
         - script: |
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -27,7 +27,7 @@ jobs:
 
         - script: |
             pip install pytest pytest-azurepipelines
-            pytest
+            pytest --ignore=samples-v2
           displayName: 'pytest'
         - script: |
             python setup.py sdist bdist_wheel

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -22,7 +22,7 @@ jobs:
 
         - script: |
             cd azure
-            flake8 . --count --show-source --statistics
+            python -m flake8 . --count --show-source --statistics
           displayName: 'Run lint test with flake8'
 
         - script: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-@nox.session(python=["3.7","3.8"])
+@nox.session(python=["3.9","3.11"])
 def tests(session):
     # same as pip install -r -requirements.txt
     session.install("-r", "requirements.txt")
@@ -8,19 +8,19 @@ def tests(session):
     session.run("pytest", "-v", "tests")
 
 
-@nox.session(python=["3.7", "3.8"])
+@nox.session(python=["3.9","3.11"])
 def lint(session):
     session.install("flake8")
     session.install("flake8-docstrings")
     session.run("flake8", "./azure/")
 
-@nox.session(python=["3.7", "3.8"])
+@nox.session(python=["3.9","3.11"])
 def typecheck(session):
     session.install("-r", "requirements.txt")
     session.install("mypy")
     session.run("mypy", "./azure/")
 
-@nox.session(python=["3.7", "3.8"])
+@nox.session(python=["3.9","3.11"])
 def autopep(session):
     session.install("-r", "requirements.txt")
     session.run("autopep8", "--in-place --aggressive --aggressive --recursive \"./azure/\"")


### PR DESCRIPTION
Addresses several issues with the official CI, including bumping the minimum Python version to 3.9 and not running the tests from the samples projects