### PR TITLE
docs: update call_http docstring to mention dict support (Fixes #518)

### DIFF
--- a/azure/durable_functions/models/DurableOrchestrationContext.py
+++ b/azure/durable_functions/models/DurableOrchestrationContext.py
@@ -246,8 +246,10 @@ class DurableOrchestrationContext:
             The HTTP request method.
         uri: str
             The HTTP request uri.
-        content: Optional[str]
-            The HTTP request content.
+        content: str or dict, optional
+            The HTTP request content. Can be a string or a JSON-serializable dictionary.
+            Note: Although the type hint says 'str', a dictionary is accepted 
+            and will be serialized to JSON.
         headers: Optional[Dict[str, str]]
             The HTTP request headers.
         token_source: TokenSource


### PR DESCRIPTION
Fixes #518

Per the discussion in the issue, I have updated the docstring for `call_http` to explicitly state that `content` accepts JSON-serializable dictionaries.

As requested by @davidmrdavid, I have limited this change to the **documentation only** and left the type hints unchanged.
