### PR TITLE
Fix ESRP rejection by upgrading setuptools for PEP 625 sdist naming

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,11 @@ stages:
     - script: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install wheel
+        # Ensure setuptools >= 69.3.0 so the sdist filename follows the
+        # PEP 625 normalized form (azure_functions_durable-*.tar.gz).
+        # Older setuptools emits the legacy hyphenated name, which ESRP
+        # rejects.
+        pip install "setuptools>=69.3.0" wheel
         # Pin an older azure-functions (< 1.26.0) that predates the
         # centralized df_dumps / df_loads serializers so this job exercises
         # the legacy serialization fallback in df_serialization. The

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -16,7 +16,11 @@ jobs:
         - script: |
             python -m pip install --upgrade pip
             pip install -r requirements.txt
-            pip install wheel
+            # Ensure setuptools >= 69.3.0 so the sdist filename follows the
+            # PEP 625 normalized form (azure_functions_durable-*.tar.gz).
+            # Older setuptools emits the legacy hyphenated name, which ESRP
+            # rejects.
+            pip install "setuptools>=69.3.0" wheel
             # Pin an older azure-functions (< 1.26.0) that predates the
             # centralized df_dumps / df_loads serializers so this job
             # exercises the legacy serialization fallback in df_serialization.


### PR DESCRIPTION
## Problem

The ESRP release failed with:

```
Filename 'azure-functions-durable-1.6.0.tar.gz' is invalid, should be 'azure_functions_durable-1.6.0.tar.gz'.
```

The sdist was produced with a legacy hyphenated filename, but ESRP/PyPI now enforce the PEP 625 normalized form (dashes -> underscores).

## Root cause

The build steps never install or upgrade setuptools, so the build uses whatever ships with the Python 3.10 venv created by UsePythonVersion@0 -- setuptools 65.5.0. PEP 625 sdist-name normalization only became the default in setuptools 69.3.0, so the older bundled version emits azure-functions-durable-*.tar.gz.

## Fix

Install setuptools>=69.3.0 (alongside wheel) before building, in both eng/templates/build.yml (official/ESRP path) and azure-pipelines.yml (CI).

## Verification

Simulated the exact build (python setup.py sdist bdist_wheel) in clean Python 3.10 venvs:

| setuptools | sdist filename | Result |
|---|---|---|
| 65.5.0 (bundled today) | azure-functions-durable-*.tar.gz | rejected |
| 69.2.0 | azure-functions-durable-*.tar.gz | hyphen |
| 69.3.0 (chosen lower bound) | azure_functions_durable-*.tar.gz | underscore |
| 83.0.0 (latest) | azure_functions_durable-*.tar.gz | underscore |

The wheel was already correctly named even with old setuptools; only the sdist was affected, so this is the only change required.