### PR TITLE
Install setuptools_scm via pip to fix vcs_versioning build failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,13 +37,6 @@ stages:
     - script: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        # Ensure setuptools >= 69.3.0 so the sdist filename follows the
-        # PEP 625 normalized form (azure_functions_durable-*.tar.gz).
-        # Older setuptools emits the legacy hyphenated name, which ESRP
-        # rejects. setuptools_scm is installed via pip (rather than left
-        # to setup.py's setup_requires) so its transitive dependency
-        # vcs_versioning is resolved; the deprecated setup_requires
-        # egg-fetch path does not install transitive deps and fails.
         pip install "setuptools>=69.3.0" setuptools_scm wheel
         # Pin an older azure-functions (< 1.26.0) that predates the
         # centralized df_dumps / df_loads serializers so this job exercises

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,11 @@ stages:
         # Ensure setuptools >= 69.3.0 so the sdist filename follows the
         # PEP 625 normalized form (azure_functions_durable-*.tar.gz).
         # Older setuptools emits the legacy hyphenated name, which ESRP
-        # rejects.
-        pip install "setuptools>=69.3.0" wheel
+        # rejects. setuptools_scm is installed via pip (rather than left
+        # to setup.py's setup_requires) so its transitive dependency
+        # vcs_versioning is resolved; the deprecated setup_requires
+        # egg-fetch path does not install transitive deps and fails.
+        pip install "setuptools>=69.3.0" setuptools_scm wheel
         # Pin an older azure-functions (< 1.26.0) that predates the
         # centralized df_dumps / df_loads serializers so this job exercises
         # the legacy serialization fallback in df_serialization. The

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -16,11 +16,7 @@ jobs:
         - script: |
             python -m pip install --upgrade pip
             pip install -r requirements.txt
-            # Ensure setuptools >= 69.3.0 so the sdist filename follows the
-            # PEP 625 normalized form (azure_functions_durable-*.tar.gz).
-            # Older setuptools emits the legacy hyphenated name, which ESRP
-            # rejects.
-            pip install "setuptools>=69.3.0" wheel
+            pip install "setuptools>=69.3.0" setuptools_scm wheel
             # Pin an older azure-functions (< 1.26.0) that predates the
             # centralized df_dumps / df_loads serializers so this job
             # exercises the legacy serialization fallback in df_serialization.

--- a/eng/templates/build.yml
+++ b/eng/templates/build.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.10.x'
+            versionSpec: '3.10'
         - script: |
             python -m pip install --upgrade pip
             pip install -r requirements.txt

--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -1,7 +1,7 @@
 from azure.durable_functions.models.actions.WhenAnyAction import WhenAnyAction
 from azure.durable_functions.models.actions.WhenAllAction import WhenAllAction
 from azure.durable_functions.models.ReplaySchema import ReplaySchema
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from .orchestrator_test_utils \
     import assert_orchestration_state_equals, get_orchestration_state_result, assert_valid_schema
 from tests.test_utils.ContextBuilder import ContextBuilder
@@ -703,7 +703,7 @@ def test_utc_time_is_never_none():
 def test_utc_time_updates_correctly():
     """Tests that current_utc_datetime updates correctly"""
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     # the first orchestrator-started event starts 1 second after `now`
     context_builder = ContextBuilder('test_simple_function', starting_time=now)
     add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"")


### PR DESCRIPTION
## Problem

Follow-up to #609. With setuptools upgraded to >= 69.3.0, the build now fails earlier with:

```
File ".eggs/setuptools_scm-10.2.0-py3.10.egg/setuptools_scm/__init__.py", line 8, in <module>
    from vcs_versioning import Configuration
ModuleNotFoundError: No module named 'vcs_versioning'
```

## Root cause

setup.py declares `setup_requires=['setuptools_scm']`, which triggers setuptools' deprecated `fetch_build_eggs` path. That path fetches setuptools_scm as an egg into `.eggs/` but does NOT install its transitive dependency `vcs_versioning` (split out as a separate distribution in setuptools_scm 10.x). Importing setuptools_scm then fails.

This did not surface in #609's local simulation because that run happened to have setuptools_scm already pip-installed (which also pulls vcs_versioning), masking the egg-fetch path the agents actually use.

## Fix

Install `setuptools_scm` via pip in both pipelines. Once the requirement is already satisfied in the environment, setuptools skips the deprecated egg-fetch entirely, and pip has resolved `vcs_versioning` transitively.

## Verification

Reproduced the agent path in a clean Python 3.10 venv (requirements + `setuptools>=69.3.0 wheel`, no explicit setuptools_scm) -> `ModuleNotFoundError: No module named 'vcs_versioning'`. After adding `pip install setuptools_scm` the build succeeds and still emits the PEP 625 normalized `azure_functions_durable-*.tar.gz`.