### PR TITLE
Fix durableClient binding FunctionLoadError on Python 3.14 (PEP 649/749)

### DIFF
--- a/azure/durable_functions/decorators/durable_app.py
+++ b/azure/durable_functions/decorators/durable_app.py
@@ -220,6 +220,16 @@ class Blueprint(TriggerApi, BindingApi, SettingsApi):
             # Invoke user code with rich DF Client binding
             return await user_code(*args, **kwargs)
 
+        # functools.wraps on Python 3.14 (PEP 649/749) copies __annotate__ rather than
+        # __annotations__, which re-derives the original client annotation and defeats the
+        # str override above. Re-apply it on the wrapper and drop __annotate__ so both the
+        # dict-based and __annotate__-based readers (the worker uses the latter on 3.14) agree.
+        _ann = dict(getattr(df_client_middleware, "__annotations__", {}))  # materializes on 3.14
+        _ann[parameter_name] = str
+        df_client_middleware.__annotations__ = _ann
+        if hasattr(df_client_middleware, "__annotate__"):
+            df_client_middleware.__annotate__ = None
+
         # Todo: This feels awkward - however, there are two reasons that I can't naively implement
         # this in the same way as entities and orchestrators:
         # 1. We intentionally wrap this exported signature with @wraps, to preserve the original

--- a/tests/models/test_Decorators.py
+++ b/tests/models/test_Decorators.py
@@ -1,3 +1,5 @@
+import sys
+
 import azure.durable_functions as df
 import azure.functions as func
 import json
@@ -7,6 +9,15 @@ def get_user_code(app):
     functions = app.get_functions()
     assert len(functions) == 1
     return functions[0]
+
+
+def get_built_function(app):
+    """Return the built callable the worker introspects for binding type-checks.
+
+    ``_add_rich_client`` wraps the user function; the wrapper is stored on the
+    indexed ``Function`` object at ``._func``.
+    """
+    return get_user_code(app)._func
 
 def assert_json(user_code, expected_dict):
     user_code_json = json.dumps(json.loads(str(user_code)), sort_keys=True)
@@ -122,3 +133,37 @@ def test_durable_client_input(app):
             }
         ]
     })
+
+
+def test_durable_client_input_annotation_overridden_to_str(app):
+    """The client-binding parameter annotation reads as ``str`` on the built function.
+
+    The worker type-checks the ``durableClient`` binding against the client
+    parameter's annotation. ``_add_rich_client`` forces that annotation to
+    ``str`` so the rich ``DurableOrchestrationClient`` object passes validation.
+
+    On Python 3.14 (PEP 649/749) ``functools.wraps`` copies ``__annotate__``
+    rather than the already-patched ``__annotations__`` dict, so the wrapper
+    re-derives the original ``DurableOrchestrationClient`` annotation and binding
+    validation fails (``FunctionLoadError`` -> host 503). This asserts the ``str``
+    override survives on the wrapper the worker actually reads, via both the
+    dict-based reader and the ``__annotate__``-based reader used on 3.14.
+    """
+
+    @app.durable_client_input(client_name="client")
+    @app.route(route="orchestrators/{functionName}")
+    async def dummy_function(req: func.HttpRequest,
+                             client: df.DurableOrchestrationClient):
+        pass
+
+    built_fn = get_built_function(app)
+
+    # Dict-based reader (used on <=3.13, still consulted on 3.14).
+    assert built_fn.__annotations__["client"] is str
+
+    # __annotate__-based reader: what the worker uses on Python 3.14.
+    if sys.version_info >= (3, 14):
+        import annotationlib
+        annotations = annotationlib.get_annotations(
+            built_fn, format=annotationlib.Format.FORWARDREF)
+        assert annotations["client"] is str


### PR DESCRIPTION
## Problem

On Python 3.14, a function app that uses `@app.durable_client_input(...)` fails to start: the `durableClient` binding fails type validation in the Functions Python worker, raising `FunctionLoadError`, and the host returns 503. The same app works on Python ≤3.13.

Fixes #596.

## Root cause

`DFApp._add_rich_client` makes the worker's binding type-check pass by forcing the client parameter's annotation to `str`:

```python
user_code.__annotations__[parameter_name] = str
```

…and then wraps the user function with `@functools.wraps(user_code)` into `df_client_middleware`.

PEP 649 / PEP 749 (Python 3.14) changed how annotations are stored: functions now carry an `__annotate__` callable, and `functools.WRAPPER_ASSIGNMENTS` copies `__annotate__` instead of the `__annotations__` dict. The copied `__annotate__` lazily **re-derives the original** `DurableOrchestrationClient` annotation, overriding the `str` patch. The worker reads the wrapper's annotation as `DurableOrchestrationClient`, `durableClient` binding validation fails, and startup 503s.

On Python ≤3.13 there is no `__annotate__`, so `wraps` copied the already-patched `__annotations__` dict and everything worked.

## Fix

After the `@wraps` wrapper is created, re-apply the `str` override on the wrapper and drop its `__annotate__`, so both the dict-based reader and the `__annotate__`-based reader (used by the worker on 3.14) agree:

```python
_ann = dict(getattr(df_client_middleware, "__annotations__", {}))
_ann[parameter_name] = str
df_client_middleware.__annotations__ = _ann
if hasattr(df_client_middleware, "__annotate__"):
    df_client_middleware.__annotate__ = None
```

The pre-wrap patch is kept for the ≤3.13 path. The block is a guarded no-op on ≤3.13 (`hasattr(__annotate__)` is False there). Runtime behavior is unchanged: the rich `DurableOrchestrationClient` is still constructed from the starter string and passed to user code — only the *annotation the worker inspects* is forced to `str`.

## Testing

- New regression test `test_durable_client_input_annotation_overridden_to_str` asserts the built wrapper's client-parameter annotation reads as `str` via both `__annotations__` and (on 3.14) `annotationlib.get_annotations(..., format=Format.FORWARDREF)`. It fails on 3.14 without the fix and passes with it.
- Full suite: **310 passed** on Python 3.14.6.
- Decorator tests also pass on Python 3.13.7 (no regression on the pre-PEP-649 path).
- `flake8 ./azure/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
