### PR TITLE
Fix shadowed when-any regression test

### DIFF
--- a/tests/orchestrator/test_sequential_orchestrator.py
+++ b/tests/orchestrator/test_sequential_orchestrator.py
@@ -791,7 +791,7 @@ def test_reducing_when_any_pattern():
 
     assert_orchestration_state_equals(expected, result)
 
-def test_reducing_when_any_pattern():
+def test_reusing_task_in_when_any_pattern():
     """Tests that a user can call when_any on a progressively smaller list of already scheduled tasks"""
     context_builder = ContextBuilder('generator_function_reuse_task_in_whenany', replay_schema=ReplaySchema.V2)
     add_hello_completed_events(context_builder, 0, "\"Hello Tokyo!\"")


### PR DESCRIPTION
## Summary

- give the second when-any regression test a unique name
- ensure pytest collects both the progressively shrinking task-set case and the reused-task case

## Testing

- `python -m pytest tests\orchestrator\test_sequential_orchestrator.py -q` (23 passed)